### PR TITLE
Add travis config to pull build dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: node_js
+node_js:
+  - "12"
+services:
+  - docker
+before_install:
+  - sudo chown -R travis ./travis/setup.sh
+  - sudo chmod +x ./travis/setup.sh ./travis/test_measures.sh
+  - ./travis/setup.sh
+script: ./travis/test_measures.sh

--- a/travis/setup.sh
+++ b/travis/setup.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+echo ">Installing FHIR Bundle Caluclator CLI..."
+npm install -g fhir-bundle-calculator
+
+echo "> Cloning FHIR Generated Patients..."
+git clone https://github.com/projecttacoma/fhir-patient-generator.git

--- a/travis/test_measures.sh
+++ b/travis/test_measures.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+cd fhir-patient-generator
+
+# Use make commands to test measures and/or
+# compare calculation results against the
+# existing patient sets.


### PR DESCRIPTION
This is just copied over from https://github.com/projecttacoma/draft-measures/pull/1. Just to be sure, I tested it with a fhir-patient-generator `make` command and the [build](https://travis-ci.com/github/projecttacoma/connectathon/builds/154242383) passed.