### PR TITLE
CI Tool Patient Calculate

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,16 @@
 language: node_js
 node_js:
   - "12"
+env:
+  - MEASURE=EXM_104
+  - MEASURE=EXM_105
+  - MEASURE=EXM_124
+  - MEASURE=EXM_125
+  - MEASURE=EXM_130
 services:
   - docker
 before_install:
   - sudo chown -R travis ./travis/setup.sh
   - sudo chmod +x ./travis/setup.sh ./travis/test_measures.sh ./travis/download_cqf_tooling.sh ./travis/rebuild_bundles.sh
   - ./travis/setup.sh
-script: ./travis/test_measures.sh
+script: ./travis/test_measures.sh $MEASURE

--- a/fhir4/input/pagecontent/cql/EXM104_FHIR4-8.1.000.cql
+++ b/fhir4/input/pagecontent/cql/EXM104_FHIR4-8.1.000.cql
@@ -76,7 +76,7 @@ define "Denominator Exclusion":
 define "Numerator":
 	TJC."Ischemic Stroke Encounter" IschemicStrokeEncounter
 		with "Antithrombotic Therapy at Discharge" DischargeAntithrombotic
-			such that DischargeAntithrombotic.authoredOn during Global."Normalize Interval"(IschemicStrokeEncounter.period)
+			such that DischargeAntithrombotic.authoredOn before start of Global."Normalize Interval"(IschemicStrokeEncounter.period)
 
 define "Antithrombotic Therapy at Discharge":
 	["MedicationRequest": medication in "Antithrombotic Therapy"] Antithrombotic

--- a/fhir4/input/pagecontent/cql/EXM104_FHIR4-8.1.000.cql
+++ b/fhir4/input/pagecontent/cql/EXM104_FHIR4-8.1.000.cql
@@ -76,7 +76,7 @@ define "Denominator Exclusion":
 define "Numerator":
 	TJC."Ischemic Stroke Encounter" IschemicStrokeEncounter
 		with "Antithrombotic Therapy at Discharge" DischargeAntithrombotic
-			such that DischargeAntithrombotic.authoredOn before start of Global."Normalize Interval"(IschemicStrokeEncounter.period)
+			such that DischargeAntithrombotic.authoredOn during Global."Normalize Interval"(IschemicStrokeEncounter.period)
 
 define "Antithrombotic Therapy at Discharge":
 	["MedicationRequest": medication in "Antithrombotic Therapy"] Antithrombotic

--- a/travis/calculateMeasures.js
+++ b/travis/calculateMeasures.js
@@ -45,7 +45,8 @@ async function calculateMeasuresAndCompare() {
     // Grab the corresponding information about the cqf-ruler measure
     let cqfMeasure = cqfMeasures.find((measure) => measure.exmId == testPatientMeasure.exmId);
     if (!cqfMeasure) {
-      console.log(`Measure ${testPatientMeasure.exmId} not found in cqf-ruler.`);
+      console.log(`Measure ${testPatientMeasure.exmId} not found in cqf-ruler. Skipping.`);
+      continue;
     }
 
     // Load up all test patients for this measure.

--- a/travis/calculateMeasures.js
+++ b/travis/calculateMeasures.js
@@ -1,221 +1,7 @@
-const fs = require('fs');
-const http = require('http');
-const process = require('process')
+const process = require('process');
 const measureReportCompare = require('./measureReportCompare');
-
-const PERIOD_START = '2019-01-01';
-const PERIOD_END = '2019-12-31';
-
-async function getCQFMeasureList() {
-  return new Promise((resolve, reject) => {
-    http.get("http://localhost:8080/cqf-ruler-r4/fhir/Measure", (res) => {
-      
-      if (res.statusCode != 200) {
-        reject(`Status code ${res.statusCode} was unexpected when listing measures.`);
-        return;
-      }
-
-      res.setEncoding('utf8');
-      let rawData = '';
-      res.on('data', (chunk) => { rawData += chunk; });
-      res.on('end', () => {
-        try {
-          const measureSearchBundle = JSON.parse(rawData);
-
-          const measureListing = measureSearchBundle.entry.map((entry) => {
-            let cmsId = entry.resource.identifier.find((identifier) => { return identifier.system == "http://hl7.org/fhir/cqi/ecqm/Measure/Identifier/cms" });
-            let exmId = "EXM_UNKNOWN";
-            if (cmsId) {
-              exmId = `EXM_${cmsId.value}`
-            }
-            return {
-              fullUrl: entry.fullUrl,
-              id: entry.resource.id,
-              exmId: exmId
-            };
-          });
-
-          resolve(measureListing);
-        } catch (e) {
-          reject(`Failed to parse result from cqf-ruler: ${e.message}`);
-          return;
-        }
-      });
-    });
-  });
-}
-
-async function getTestMeasureList() {
-  let fpgDir = fs.readdirSync('./fhir-patient-generator/')
-  let applicableMeasuresDirs = fpgDir.filter((dir) => { return dir.startsWith("EXM_") });
-  let measureDirInfo = applicableMeasuresDirs.map((measureDir) => {
-    let testDirInfo = {
-      exmId: measureDir,
-      path: `./fhir-patient-generator/${measureDir}/patients-r4`
-    };
-    let measureReportFile = fs.readdirSync(testDirInfo.path).find((filename) => { return filename.includes('measure-report.json')});
-    if (measureReportFile) {
-      testDirInfo.measureReportPath = `${testDirInfo.path}/${measureReportFile}`;
-    }
-    return testDirInfo;
-  });
-
-  return measureDirInfo;
-}
-
-async function loadTestDataFolder(testDataFolder) {
-  // use data in all subfolders. ex. numerator, denominator, etc.
-  let subfolders = fs.readdirSync(testDataFolder, { withFileTypes: true })
-    .filter((dir) => { return dir.isDirectory() })
-    .map((dir) => { return dir.name })
-
-  let bundleResourceInfos = [];
-  for (let subfolder of subfolders) {
-    // skip measure-reports folder
-    if (subfolder == 'measure-reports') continue;
-    let subfolderPath = testDataFolder + '/' + subfolder;
-    let patientBundles = fs.readdirSync(subfolderPath)
-    for (let patientBundleName of patientBundles) {
-      if (!patientBundleName.endsWith(".json")) continue;
-      process.stdout.write('.');
-      //console.log(`Loading bundle ${subfolderPath}/${patientBundleName}`)
-      let newResourceInfo = await loadPatientBundle(`${subfolderPath}/${patientBundleName}`)
-      bundleResourceInfos.push(newResourceInfo);
-    }
-  }
-  console.log();
-  return bundleResourceInfos;
-}
-
-async function loadPatientBundle(patientBundlePath) {
-  return new Promise((resolve, reject) => {
-    let req = http.request("http://localhost:8080/cqf-ruler-r4/fhir",
-      {
-        method: 'POST',
-        headers: {
-          "Content-Type": 'application/json'
-        }
-      }, (res) => {
-        if (res.statusCode != 200) {
-          reject(`Status code ${res.statusCode} was unexpected when posting bundle. ${patientBundlePath}`);
-          return;
-        }
-
-        res.setEncoding('utf8');
-        let rawData = '';
-        res.on('data', (chunk) => { rawData += chunk; });
-        res.on('end', () => {
-          let transactionResult = JSON.parse(rawData);
-          let resourcesCreated = transactionResult.entry.map((entry) => {
-            return entry.response.location.replace("/_history/1", '');
-          })
-          resolve({
-            originalBundle: patientBundlePath,
-            resources: resourcesCreated
-          });
-        });
-      });
-
-    let bundleStream = fs.createReadStream(patientBundlePath);
-    bundleStream.pipe(req);
-  });
-}
-
-async function deleteBundleResources(bundleResourceInfos) {
-  for (let bundleResourceInfo of bundleResourceInfos) {
-    process.stdout.write('.');
-    //console.log("Deleting resources from " + bundleResourceInfo.originalBundle)
-    await deleteResources(bundleResourceInfo.resources);
-  }
-  console.log();
-}
-
-async function deleteResources(resourcesToDelete) {
-  let deleteTransaction = {
-    resourceType: 'Bundle',
-    id: 'big-delete',
-    type: 'transaction',
-    entry: resourcesToDelete.map((resource) => {
-      return {
-        request: {
-          method: 'DELETE',
-          url: resource
-        }
-      };
-    })
-  };
-
-  return new Promise((resolve, reject) => {
-    let req = http.request("http://localhost:8080/cqf-ruler-r4/fhir",
-      {
-        method: 'POST',
-        headers: {
-          "Content-Type": 'application/json'
-        }
-      }, (res) => {
-        if (res.statusCode != 200) {
-          reject(`Status code ${res.statusCode} was unexpected when deleting data.`);
-          return;
-        } else {
-          resolve();
-        }
-      });
-    req.write(JSON.stringify(deleteTransaction));
-    req.end();
-  });
-}
-
-async function getFakeMeasureReport(measureId) {
-  return loadReferenceMeasureReport('./travis/exm124-mr.json');
-}
-
-async function loadReferenceMeasureReport(measureReportPath) {
-  return new Promise((resolve, reject) => {
-    fs.readFile(measureReportPath, (err, data) => {
-      if (err) reject(err);
-      resolve(JSON.parse(data));
-    });
-  });
-}
-
-async function getMeasureReport(measureId) {
-  return new Promise((resolve, reject) => {
-    let dotTimer;
-    console.log(`Executing measure ${measureId}`);
-    let req = http.request(`http://localhost:8080/cqf-ruler-r4/fhir/Measure/${measureId}/$evaluate-measure?reportType=patient-list&periodStart=${PERIOD_START}&periodEnd=${PERIOD_END}`,
-      {
-        method: 'GET',
-        timeout: 2400000 //40 minute timeout because this is slow for some measures.
-      }, (res) => {
-        clearInterval(dotTimer);
-        console.log();
-        console.timeEnd(`Execute ${measureId}`);
-        if (res.statusCode != 200) {
-          reject(`Status code ${res.statusCode} was unexpected when posting bundle.`);
-          return;
-        } else {
-          res.setEncoding('utf8');
-          let rawData = '';
-          res.on('data', (chunk) => { rawData += chunk; });
-          res.on('end', () => {
-            resolve(JSON.parse(rawData));
-          });
-        }
-      }
-    );
-
-    req.on('error', (e) => {
-      console.error(e);
-      reject(e);
-    });
-    req.end();
-    console.time(`Execute ${measureId}`);
-    // Dots are required to keep travis from giving up.
-    dotTimer = setInterval(() => { process.stdout.write('.') }, 10000);
-  });
-}
-
-
+const fhirInteractions = require('./fhirInteractions');
+const testDataHelpers = require('./testDataHelpers');
 
 async function calculateMeasuresAndCompare() {
   // look for an argument on the command line to indicate the only measure to run. i.e. EXM_105
@@ -226,9 +12,8 @@ async function calculateMeasuresAndCompare() {
   }
 
   // grab info on measures in cqf-ruler and measures in test data
-  let measureDiffInfo = [];
-  let cqfMeasures = await getCQFMeasureList();
-  let testPatientMeasures = await getTestMeasureList();
+  let cqfMeasures = await fhirInteractions.getCQFMeasureList();
+  let testPatientMeasures = await testDataHelpers.getTestMeasureList();
 
   // if we are testing only one measure check it exists in both test data and cqf-ruler
   if (onlyMeasureExmId &&
@@ -237,16 +22,19 @@ async function calculateMeasuresAndCompare() {
       throw new Error(`Measure ${onlyMeasureExmId} was not found in cqf-ruler or in test data and was the only measure requested.`)
   }
 
-  // iterate over test data measures
+  // Array for collecting diff information to print at end.
+  let measureDiffInfo = [];
+
+  // Iterate over test data measures
   for (let testPatientMeasure of testPatientMeasures) {
-    // skip if this isn't the only one we should run
+    // Skip if we are in run one mode and this is not the only one we should run
     if (onlyMeasureExmId && testPatientMeasure.exmId != onlyMeasureExmId) continue;
 
-    // check if there is a MeasureReport to compare to
+    // Check if there is a MeasureReport to compare to
     if (!testPatientMeasure.measureReportPath) {
       console.log(`No Reference MeasureReport found for ${testPatientMeasure.exmId}`);
 
-      // if we are only runing one measure throw an error if we cannot find the report
+      // If we are only runing one measure throw an error if we cannot find the report, otherwise skip to the next one
       if (onlyMeasureExmId) {
         throw new Error(`Measure ${onlyMeasureExmId} does not have a reference MeasureReport and was the only measure requested.`)
       } else {
@@ -254,26 +42,33 @@ async function calculateMeasuresAndCompare() {
       }
     }
 
-    let cqfMeasure = cqfMeasures.find((measure) => measure.exmId == testPatientMeasure.exmId)
+    // Grab the corresponding information about the cqf-ruler measure
+    let cqfMeasure = cqfMeasures.find((measure) => measure.exmId == testPatientMeasure.exmId);
     if (!cqfMeasure) {
-      console.log(`Measure ${testPatientMeasure.exmId} not found in cqf-ruler.`)
+      console.log(`Measure ${testPatientMeasure.exmId} not found in cqf-ruler.`);
     }
 
+    // Load up all test patients for this measure.
     console.log(`Loading test data for ${testPatientMeasure.exmId}`);
-    let bundleResourceInfos = await loadTestDataFolder(testPatientMeasure.path);
+    let bundleResourceInfos = await testDataHelpers.loadTestDataFolder(testPatientMeasure.path);
 
-    let report = await getMeasureReport(cqfMeasure.id)
-    let referenceReport = await loadReferenceMeasureReport(testPatientMeasure.measureReportPath);
+    // Execute the measure, i.e. get the MeasureReport from cqf-ruler
+    let report = await fhirInteractions.getMeasureReport(cqfMeasure.id)
+    // Load the reference report from the test data
+    let referenceReport = await testDataHelpers.loadReferenceMeasureReport(testPatientMeasure.measureReportPath);
 
+    // Compare measure reports and get the list of information about patients with discrepancies
     let badPatients = measureReportCompare.compareMeasureReports(referenceReport, report)
 
+    // Add to the measure info to print at the end
     measureDiffInfo.push({
       exmId: testPatientMeasure.exmId,
       badPatients: badPatients
     })
 
+    // Clean up the test patients so they don't pollute the next test.
     console.log(`Removing test data for ${testPatientMeasure.exmId}`);
-    await deleteBundleResources(bundleResourceInfos);
+    await testDataHelpers.deleteBundleResources(bundleResourceInfos);
   }
 
   return measureDiffInfo;
@@ -281,14 +76,19 @@ async function calculateMeasuresAndCompare() {
 
 
 calculateMeasuresAndCompare()
+  // Print listing of measures and differences found and exit.
   .then((measureDiffInfo) => {
+
     console.log();
     console.log("--- RESULTS ---");
     console.log();
     let hasDifferences = false;
 
+    // Iterate over measures
     measureDiffInfo.forEach((measureDiff) => {
       console.log(`MEASURE ${measureDiff.exmId}`);
+
+      // Iterate over the listing of discrepancies for this measure if there are any
       if (measureDiff.badPatients.length > 0) {
         hasDifferences = true;
         measureDiff.badPatients.forEach((patient) => {
@@ -297,17 +97,20 @@ calculateMeasuresAndCompare()
             console.log(`|   ${issue}`)
           });
         });
+
+      // If there were no discrepancies
       } else {
         console.log("  No Issues!");
       }
       console.log();
     });
 
-
+    // If there were discrepancies, return with non-zero exit status
     if (hasDifferences) {
       process.exit(1);
     }
   })
+  // Handle errors by printing and return non-zero exit status
   .catch((reason) => {
     console.error(reason);
     process.exit(2);

--- a/travis/calculateMeasures.js
+++ b/travis/calculateMeasures.js
@@ -1,5 +1,10 @@
 const fs = require('fs');
 const http = require('http');
+const process = require('process')
+const measureReportCompare = require('./measureReportCompare');
+
+const PERIOD_START = '2019-01-01';
+const PERIOD_END = '2019-12-31';
 
 async function getCQFMeasureList() {
   return new Promise((resolve, reject) => {
@@ -44,10 +49,15 @@ async function getTestMeasureList() {
   let fpgDir = fs.readdirSync('./fhir-patient-generator/')
   let applicableMeasuresDirs = fpgDir.filter((dir) => { return dir.startsWith("EXM_") });
   let measureDirInfo = applicableMeasuresDirs.map((measureDir) => {
-    return {
+    let testDirInfo = {
       exmId: measureDir,
       path: `./fhir-patient-generator/${measureDir}/patients-r4`
+    };
+    let measureReportFile = fs.readdirSync(testDirInfo.path).find((filename) => { return filename.includes('measure-report')});
+    if (measureReportFile) {
+      testDirInfo.measureReportPath = `${testDirInfo.path}/${measureReportFile}`;
     }
+    return testDirInfo;
   });
 
   return measureDirInfo;
@@ -59,16 +69,19 @@ async function loadTestDataFolder(testDataFolder) {
     .filter((dir) => { return dir.isDirectory() })
     .map((dir) => { return dir.name })
 
+  let bundleResourceInfos = [];
   for (let subfolder of subfolders) {
     let subfolderPath = testDataFolder + '/' + subfolder;
-    console.log(subfolderPath);
     let patientBundles = fs.readdirSync(subfolderPath)
     for (let patientBundleName of patientBundles) {
       if (!patientBundleName.endsWith(".json")) continue;
-      console.log(`${subfolderPath}/${patientBundleName}`)
-      await loadPatientBundle(`${subfolderPath}/${patientBundleName}`)
+      console.log(`Loading bundle ${subfolderPath}/${patientBundleName}`)
+      let newResourceInfo = await loadPatientBundle(`${subfolderPath}/${patientBundleName}`)
+      bundleResourceInfos.push(newResourceInfo);
     }
   }
+
+  return bundleResourceInfos;
 }
 
 async function loadPatientBundle(patientBundlePath) {
@@ -83,9 +96,21 @@ async function loadPatientBundle(patientBundlePath) {
         if (res.statusCode != 200) {
           reject(`Status code ${res.statusCode} was unexpected when posting bundle.`);
           return;
-        } else {
-          resolve();
         }
+
+        res.setEncoding('utf8');
+        let rawData = '';
+        res.on('data', (chunk) => { rawData += chunk; });
+        res.on('end', () => {
+          let transactionResult = JSON.parse(rawData);
+          let resourcesCreated = transactionResult.entry.map((entry) => {
+            return entry.response.location.replace("/_history/1", '');
+          })
+          resolve({
+            originalBundle: patientBundlePath,
+            resources: resourcesCreated
+          });
+        });
       });
 
     let bundleStream = fs.createReadStream(patientBundlePath);
@@ -93,13 +118,158 @@ async function loadPatientBundle(patientBundlePath) {
   });
 }
 
-async function calculateMeasures() {
+async function deleteBundleResources(bundleResourceInfos) {
+  for (let bundleResourceInfo of bundleResourceInfos) {
+    console.log("Deleting resources from " + bundleResourceInfo.originalBundle)
+    await deleteResources(bundleResourceInfo.resources);
+  }
+}
+
+async function deleteResources(resourcesToDelete) {
+  let deleteTransaction = {
+    resourceType: 'Bundle',
+    id: 'big-delete',
+    type: 'transaction',
+    entry: resourcesToDelete.map((resource) => {
+      return {
+        request: {
+          method: 'DELETE',
+          url: resource
+        }
+      };
+    })
+  };
+
+  return new Promise((resolve, reject) => {
+    let req = http.request("http://localhost:8080/cqf-ruler-r4/fhir",
+      {
+        method: 'POST',
+        headers: {
+          "Content-Type": 'application/json'
+        }
+      }, (res) => {
+        if (res.statusCode != 200) {
+          reject(`Status code ${res.statusCode} was unexpected when deleting data.`);
+          return;
+        } else {
+          resolve();
+        }
+      });
+    req.write(JSON.stringify(deleteTransaction));
+    req.end();
+  });
+}
+
+async function getFakeMeasureReport(measureId) {
+  return loadReferenceMeasureReport('./travis/exm124-mr.json');
+}
+
+async function loadReferenceMeasureReport(measureReportPath) {
+  return new Promise((resolve, reject) => {
+    fs.readFile(measureReportPath, (err, data) => {
+      if (err) reject(err);
+      resolve(JSON.parse(data));
+    });
+  });
+}
+
+async function getMeasureReport(measureId) {
+  return new Promise((resolve, reject) => {
+    console.log(`Executing measure ${measureId}`);
+    let req = http.request(`http://localhost:8080/cqf-ruler-r4/fhir/Measure/${measureId}/$evaluate-measure?reportType=patient-list&periodStart=${PERIOD_START}&periodEnd=${PERIOD_END}`,
+      {
+        method: 'GET',
+        timeout: 480 //8 minute timeout because this is slooooow
+      }, (res) => {
+        if (res.statusCode != 200) {
+          reject(`Status code ${res.statusCode} was unexpected when posting bundle.`);
+          return;
+        } else {
+          res.setEncoding('utf8');
+          let rawData = '';
+          res.on('data', (chunk) => { rawData += chunk; });
+          res.on('end', () => {
+            resolve(JSON.parse(rawData));
+          });
+        }
+      }
+    );
+
+    req.on('error', (e) => {
+      console.error(e);
+      reject(e);
+    });
+    req.end();
+  });
+}
+
+
+
+async function calculateMeasuresAndCompare() {
+  let measureDiffInfo = [];
   let cqfMeasures = await getCQFMeasureList();
   console.log(cqfMeasures);
   let testPatientMeasures = await getTestMeasureList();
   console.log(testPatientMeasures);
-  loadTestDataFolder('./fhir-patient-generator/EXM_124/patients-r4');
+
+  for (let testPatientMeasure of testPatientMeasures) {
+    if (testPatientMeasure.exmId != 'EXM_124') continue; // TODO remove this when ready to try with all measures
+
+    let cqfMeasure = cqfMeasures.find((measure) => measure.exmId == testPatientMeasure.exmId)
+    if (!cqfMeasure) {
+      console.log(`Measure ${testPatientMeasure.exmId} not found in cqf-ruler.`)
+    }
+
+    console.log(`Loading test data for ${testPatientMeasure.exmId}`);
+    let bundleResourceInfos = await loadTestDataFolder(testPatientMeasure.path);
+
+    let report = await getMeasureReport(cqfMeasure.id)
+    let referenceReport = await loadReferenceMeasureReport(testPatientMeasure.measureReportPath);
+
+    let badPatients = measureReportCompare.compareMeasureReports(referenceReport, report)
+
+    measureDiffInfo.push({
+      exmId: testPatientMeasure.exmId,
+      badPatients: badPatients
+    })
+
+    console.log(`Removing test data for ${testPatientMeasure.exmId}`);
+    await deleteBundleResources(bundleResourceInfos);
+  }
+
+  return measureDiffInfo;
 }
 
 
-calculateMeasures();
+calculateMeasuresAndCompare()
+  .then((measureDiffInfo) => {
+    console.log();
+    console.log("--- RESULTS ---");
+    console.log();
+    let hasDifferences = false;
+
+    measureDiffInfo.forEach((measureDiff) => {
+      console.log(`MEASURE ${measureDiff.exmId}`);
+      if (measureDiff.badPatients.length > 0) {
+        hasDifferences = true;
+        measureDiff.badPatients.forEach((patient) => {
+          console.log(`|- ${patient.patientName}`);
+          patient.issues.forEach((issue) => {
+            console.log(`|   ${issue}`)
+          });
+        });
+      } else {
+        console.log("  No Issues!");
+      }
+      console.log();
+    });
+
+
+    if (hasDifferences) {
+      process.exit(1);
+    }
+  })
+  .catch((reason) => {
+    console.error(reason);
+    process.exit(2);
+  });

--- a/travis/calculateMeasures.js
+++ b/travis/calculateMeasures.js
@@ -213,7 +213,10 @@ async function calculateMeasuresAndCompare() {
   console.log(testPatientMeasures);
 
   for (let testPatientMeasure of testPatientMeasures) {
-    if (testPatientMeasure.exmId != 'EXM_124') continue; // TODO remove this when ready to try with all measures
+    if (!testPatientMeasure.measureReportPath) {
+      console.log(`No Reference MeasureReport found for ${testPatientMeasure.exmId}`);
+      continue;
+    }
 
     let cqfMeasure = cqfMeasures.find((measure) => measure.exmId == testPatientMeasure.exmId)
     if (!cqfMeasure) {

--- a/travis/calculateMeasures.js
+++ b/travis/calculateMeasures.js
@@ -1,0 +1,61 @@
+const fs = require('fs');
+const http = require('http');
+
+async function getCQFMeasureList() {
+  return new Promise((resolve, reject) => {
+    http.get("http://localhost:8080/cqf-ruler-r4/fhir/Measure", (res) => {
+      
+      if (res.statusCode != 200) {
+        reject(`Status code ${res.statusCode} was unexpected when listing measures.`);
+        return;
+      }
+
+      res.setEncoding('utf8');
+      let rawData = '';
+      res.on('data', (chunk) => { rawData += chunk; });
+      res.on('end', () => {
+        try {
+          const measureSearchBundle = JSON.parse(rawData);
+
+          const measureListing = measureSearchBundle.entry.map((entry) => {
+            let cmsId = entry.resource.identifier.find((identifier) => { return identifier.system == "http://hl7.org/fhir/cqi/ecqm/Measure/Identifier/cms" });
+            let exmId = "EXM_UNKNOWN";
+            if (cmsId) {
+              exmId = `EXM_${cmsId.value}`
+            }
+            return {
+              fullUrl: entry.fullUrl,
+              id: entry.resource.id,
+              exmId: exmId
+            };
+          });
+
+          resolve(measureListing);
+        } catch (e) {
+          reject(`Failed to parse result from cqf-ruler: ${e.message}`);
+          return;
+        }
+      });
+    });
+  });
+}
+
+async function getTestMeasureList() {
+  let fpgDir = fs.readdirSync('./fhir-patient-generator/')
+  let applicableMeasuresDirs = fpgDir.filter((dir) => { return dir.startsWith("EXM_") });
+  applicableMeasuresDirs.map((measureDir) => {
+    
+  });
+
+  return applicableMeasuresDirs;
+}
+
+async function calculateMeasures() {
+  let cqfMeasures = await getCQFMeasureList();
+  console.log(cqfMeasures);
+  let testPatientMeasures = await getTestMeasureList();
+  console.log(testPatientMeasures);
+}
+
+
+calculateMeasures();

--- a/travis/fhirInteractions.js
+++ b/travis/fhirInteractions.js
@@ -185,7 +185,7 @@ async function getMeasureReport(measureId) {
         console.log();
         console.timeEnd(`Execute ${measureId}`); // print out how long this took.
         if (res.statusCode != 200) {
-          reject(`Status code ${res.statusCode} was unexpected when posting bundle.`);
+          reject(`Status code ${res.statusCode} was unexpected when executing.`);
           return;
         } else {
           res.setEncoding('utf8');

--- a/travis/fhirInteractions.js
+++ b/travis/fhirInteractions.js
@@ -1,0 +1,217 @@
+const fs = require('fs');
+const http = require('http');
+const process = require('process');
+
+const PERIOD_START = '2019-01-01';
+const PERIOD_END = '2019-12-31';
+
+const FHIR_SERVER = 'http://localhost:8080/cqf-ruler-r4/fhir';
+
+/**
+ * Information about a measure in cqf-ruler.
+ * 
+ * @typedef {Object} CQFMeasureInfo
+ * @property {String} exmId - The EXM ID of the measure. ex. EXM_104
+ * @property {String} fullUrl - Full URL of the measure in the FHIR server
+ * @property {String} id - The Measure resource's id. ex. measure-EXM104-FHIR4-8.1.000
+ */
+
+/**
+ * Get information about all Measures in the cqf-ruler instance.
+ * 
+ * @returns {Promise<CQFMeasureInfo[]} List of information about the Measures.
+ */
+async function getCQFMeasureList() {
+  return new Promise((resolve, reject) => {
+    http.get(FHIR_SERVER + '/Measure', (res) => {
+      // make sure it worked, error out if the status code wasn't 200
+      if (res.statusCode != 200) {
+        reject(`Status code ${res.statusCode} was unexpected when listing measures.`);
+        return;
+      }
+
+      // collect and parse the response body into a JS object
+      res.setEncoding('utf8');
+      let rawData = '';
+      res.on('data', (chunk) => { rawData += chunk; });
+      res.on('end', () => {
+        try {
+          const measureSearchBundle = JSON.parse(rawData);
+          // iterate over each measure found
+          const measureListing = measureSearchBundle.entry.map((entry) => {
+            // find the CMS identifier of the resource and use it for the exmId. Default to EXM_UNKNOWN if it can't be found
+            let cmsId = entry.resource.identifier.find((identifier) => { return identifier.system == "http://hl7.org/fhir/cqi/ecqm/Measure/Identifier/cms" });
+            let exmId = "EXM_UNKNOWN";
+            if (cmsId) {
+              exmId = `EXM_${cmsId.value}`
+            }
+            return {
+              fullUrl: entry.fullUrl,
+              id: entry.resource.id,
+              exmId: exmId
+            };
+          });
+
+          resolve(measureListing);
+        } catch (e) {
+          reject(`Failed to parse result from cqf-ruler: ${e.message}`);
+          return;
+        }
+      });
+    });
+  });
+}
+
+/**
+ * Information about all resources that were created when a bundle was posted.
+ * 
+ * @typedef {Object} BundleLoadInfo
+ * @property {String} originalBundle - Path to the bundle that was posted.
+ * @property {String[]} resources - List of references to the FHIR Resources that were created. ex. ['Patient/123', 'Condition/12']
+ */
+
+/**
+ * Post a patient test patient bundle to the server. Collect information about the resources that were created.
+ * 
+ * @param {String} patientBundlePath Path to a FHIR Bundle to POST to cqf-ruler.
+ * @returns {Promise<BundleLoadInfo>} Information about the resources created.
+ */
+async function loadPatientBundle(patientBundlePath) {
+  return new Promise((resolve, reject) => {
+    let req = http.request(FHIR_SERVER,
+      {
+        method: 'POST',
+        headers: {
+          "Content-Type": 'application/json'
+        }
+      }, (res) => {
+        // make sure it worked, error out if the status code wasn't 200
+        if (res.statusCode != 200) {
+          reject(`Status code ${res.statusCode} was unexpected when posting bundle. ${patientBundlePath}`);
+          return;
+        }
+
+        // collect and parse the response body into a JS object
+        res.setEncoding('utf8');
+        let rawData = '';
+        res.on('data', (chunk) => { rawData += chunk; });
+        res.on('end', () => {
+          let transactionResult = JSON.parse(rawData);
+          // loop through each Resource that was created and grab the reference, clearing up the history piece
+          let resourcesCreated = transactionResult.entry.map((entry) => {
+            return entry.response.location.replace("/_history/1", '');
+          })
+          resolve({
+            originalBundle: patientBundlePath,
+            resources: resourcesCreated
+          });
+        });
+      });
+
+    // open the patient bundle file and pipe it to the request.
+    let bundleStream = fs.createReadStream(patientBundlePath);
+    bundleStream.pipe(req);
+  });
+}
+
+/**
+ * Creates a transaction bundle that does a DELETE of every resource reference passed in.
+ * 
+ * @param {String[]} resourcesToDelete List of resources to delete as relative urls. ex. ['Patient/123', 'Condition/12']
+ */
+async function deleteResources(resourcesToDelete) {
+  // Build up a Bundle that is a transaction to delete every resource.
+  let deleteTransaction = {
+    resourceType: 'Bundle',
+    id: 'big-delete',
+    type: 'transaction',
+    entry: resourcesToDelete.map((resource) => {
+      return {
+        request: {
+          method: 'DELETE',
+          url: resource
+        }
+      };
+    })
+  };
+
+  // Run the request to post the transaction.
+  return new Promise((resolve, reject) => {
+    let req = http.request(FHIR_SERVER,
+      {
+        method: 'POST',
+        headers: {
+          "Content-Type": 'application/json'
+        }
+      }, (res) => {
+        // handle response. pass if status code is 200, otherwise fail.
+        if (res.statusCode != 200) {
+          reject(`Status code ${res.statusCode} was unexpected when deleting data.`);
+          return;
+        } else {
+          resolve();
+        }
+      });
+
+    // Send the transaction Bundle.
+    req.write(JSON.stringify(deleteTransaction));
+    req.end();
+  });
+}
+
+/**
+ * The MeasureReport Resource that is a result of executing a measure.
+ * 
+ * @typedef {Object} FHIR.MeasureReport
+ */
+
+/**
+ * Run Measure/{id}/$evaluate-measure on cqf-ruler and return the MeasureReport as a JS object.
+ * 
+ * @param {String} measureId The id of the measure to execute on cqf-ruler.
+ * @returns {Promise<FHIR.MeasureReport>} The patient-list MeasureReport.
+ */
+async function getMeasureReport(measureId) {
+  return new Promise((resolve, reject) => {
+    let dotTimer;
+    console.log(`Executing measure ${measureId}`);
+    let req = http.request(`${FHIR_SERVER}/Measure/${measureId}/$evaluate-measure?reportType=patient-list&periodStart=${PERIOD_START}&periodEnd=${PERIOD_END}`,
+      {
+        method: 'GET',
+        timeout: 2400000 //40 minute timeout because this is slow for some measures.
+      }, (res) => {
+        // Handle result of execution.
+        clearInterval(dotTimer); // clear the timer for the dot printer
+        console.log();
+        console.timeEnd(`Execute ${measureId}`); // print out how long this took.
+        if (res.statusCode != 200) {
+          reject(`Status code ${res.statusCode} was unexpected when posting bundle.`);
+          return;
+        } else {
+          res.setEncoding('utf8');
+          let rawData = '';
+          res.on('data', (chunk) => { rawData += chunk; });
+          res.on('end', () => {
+            resolve(JSON.parse(rawData));
+          });
+        }
+      }
+    );
+
+    req.on('error', (e) => {
+      console.error(e);
+      reject(e);
+    });
+    req.end();
+
+    // Start a timer
+    console.time(`Execute ${measureId}`);
+    // Dots are required to keep travis from giving up.
+    dotTimer = setInterval(() => { process.stdout.write('.') }, 10000);
+  });
+}
+
+module.exports.getCQFMeasureList = getCQFMeasureList;
+module.exports.loadPatientBundle = loadPatientBundle;
+module.exports.deleteResources = deleteResources;
+module.exports.getMeasureReport = getMeasureReport;

--- a/travis/measureReportCompare.js
+++ b/travis/measureReportCompare.js
@@ -1,0 +1,76 @@
+
+function findCorrespondingGroup(referenceGroup, report) {
+  return report.group.find((group) => {
+    return referenceGroup.id == group.id
+  });
+}
+
+function findCorrespondingPopulation(referencePopulation, group) {
+  return group.population.find((population) => {
+    return referencePopulation.code.coding[0].code == population.code.coding[0].code
+  });
+}
+
+function grabReferencedResource(reference, report) {
+  let id = reference.replace('#', '');
+  return report.contained.find((resource) => { return resource.id = id });
+}
+
+function addBadPatientEntry(badPatientsList, patientName, issueMessage) {
+  let badPatient = badPatientsList.find((badPatient) => badPatient.patientName == patientName );
+  if (!badPatient) {
+    badPatient = { patientName: patientName, issues: [] };
+    badPatientsList.push(badPatient);
+  }
+
+  badPatient.issues.push(issueMessage);
+}
+
+
+function compareMeasureReports(referenceReport, report) {
+  let badPatientsList = []
+
+  console.log(`Comparing reports for ${referenceReport.measure}`);
+
+  // iterate groups in referenceReport
+  referenceReport.group.forEach(referenceGroup => {
+
+    console.log(`  Comparing group: ${referenceGroup.id}`)
+    // find corresponding group in report
+    let group = findCorrespondingGroup(referenceGroup, report);
+
+    // iterate populations
+    referenceGroup.population.forEach(referencePopulation => {
+
+      console.log(`    Comparing population: ${referencePopulation.code.coding[0].display}`)
+      // find corresponding population
+      let population = findCorrespondingPopulation(referencePopulation, group);
+
+      // grab lists of patients
+      let referenceList = grabReferencedResource(referencePopulation.subjectResults.reference, referenceReport);
+      let list = grabReferencedResource(population.subjectResults.reference, report);
+      let referencePatientNames = referenceList.entry.map((entry) => { return entry.item.display; });
+      let patientNames = list.entry.map((entry) => { return entry.item.display; });
+
+      // compare lists
+      let missingPatients = referencePatientNames.filter((patientName) => { return !patientNames.includes(patientName) });
+      let unexpectedPatients = patientNames.filter((patientName) => { return !referencePatientNames.includes(patientName) });
+
+      console.log(`      Expected ${referencePatientNames.length} - Actual ${patientNames.length}`);
+      missingPatients.forEach(patientName => {
+        console.log(`        MISSING    ${patientName}`);
+        addBadPatientEntry(badPatientsList, patientName, `Missing from ${referenceGroup.id} - ${referencePopulation.code.coding[0].display}`)
+      });
+      unexpectedPatients.forEach(patientName => {
+        console.log(`        UNEXPECTED ${patientName}`);
+        addBadPatientEntry(badPatientsList, patientName, `Unexpected in ${referenceGroup.id} - ${referencePopulation.code.coding[0].display}`)
+      });
+      // build list of patients and their membership as we do this
+    });
+  });
+
+  // return list of patients
+  return badPatientsList;
+}
+
+module.exports.compareMeasureReports = compareMeasureReports;

--- a/travis/measureReportCompare.js
+++ b/travis/measureReportCompare.js
@@ -13,7 +13,7 @@ function findCorrespondingPopulation(referencePopulation, group) {
 
 function grabReferencedResource(reference, report) {
   let id = reference.replace('#', '');
-  return report.contained.find((resource) => { return resource.id = id });
+  return report.contained.find((resource) => { return resource.id == id });
 }
 
 function addBadPatientEntry(badPatientsList, patientName, issueMessage) {
@@ -50,8 +50,11 @@ function compareMeasureReports(referenceReport, report) {
       let referenceList = grabReferencedResource(referencePopulation.subjectResults.reference, referenceReport);
       let list = grabReferencedResource(population.subjectResults.reference, report);
 
-      // Turn into list of patient names from reference report
-      let referencePatientNames = referenceList.entry.map((entry) => { return entry.item.display; });
+      // Turn into list of patient names from reference report, default to [] if list is empty/nonexistent
+      let referencePatientNames = [];
+      if (referenceList.entry) {
+        referencePatientNames = referenceList.entry.map((entry) => { return entry.item.display; });
+      }
 
       // Turn into list of patient names from calculated report. default to [] if list is empty/nonexistent
       let patientNames = [];

--- a/travis/measureReportCompare.js
+++ b/travis/measureReportCompare.js
@@ -1,33 +1,77 @@
-
+/**
+ * Finds the corresponding group in a measure report for the given reference group in.
+ * 
+ * @param {*} referenceGroup The reference group. This is the one we are trying to find the match for.
+ * @param {FHIR.MeasureReport} report The MeasureReport to find the group in.
+ * @returns {Object} The corresponding group.
+ */
 function findCorrespondingGroup(referenceGroup, report) {
   return report.group.find((group) => {
     return referenceGroup.id == group.id
   });
 }
 
+/**
+ * Finds the corresponding population result in a group for the given reference population.
+ * 
+ * @param {*} referencePopulation The reference population. This is the one we are trying to find the match for.
+ * @param {*} group The group to look for the population in.
+ * @returns {Object} The corresponding population.
+ */
 function findCorrespondingPopulation(referencePopulation, group) {
   return group.population.find((population) => {
     return referencePopulation.code.coding[0].code == population.code.coding[0].code
   });
 }
 
+/**
+ * Gets the contained Resource in a MeasureReport by '#' local reference. This is used to grab the list of patients
+ * that calculated in a population.
+ * 
+ * @param {String} reference FHIR '#' style reference to contained resource
+ * @param {FHIR.MeasureReport} report The report to find the contained reference.
+ */
 function grabReferencedResource(reference, report) {
   let id = reference.replace('#', '');
   return report.contained.find((resource) => { return resource.id == id });
 }
 
+/**
+ * Container for issues with a patient found during MeasureReport comparison.
+ * 
+ * @typedef {Object} BadPatient
+ * @property {String} patientName - Patient Name.
+ * @property {String[]} issues - List of reasons this patient is bad.
+ */
+
+/**
+ * Add an issue entry to the given bad patient list for a specific patient. Add this patient to the list if are not already in it.
+ * 
+ * @param {BadPatient[]} badPatientsList 
+ * @param {String} patientName 
+ * @param {String} issueMessage 
+ */
 function addBadPatientEntry(badPatientsList, patientName, issueMessage) {
+  // Find the patient or create them if they don't exist
   let badPatient = badPatientsList.find((badPatient) => badPatient.patientName == patientName );
   if (!badPatient) {
     badPatient = { patientName: patientName, issues: [] };
     badPatientsList.push(badPatient);
   }
 
+  // Add the issue message to their list of issues.
   badPatient.issues.push(issueMessage);
 }
 
-
+/**
+ * Compare two measure reports. Report the differences as a list of issues with each patient that has a descrepancy.
+ * 
+ * @param {FHIR.MeasureReport} referenceReport The report we are comparing the executed report to.
+ * @param {FHIR.MeasureReport} report The report coming from execution.
+ * @returns {BadPatient[]} List of bad patients and the issues with them.
+ */
 function compareMeasureReports(referenceReport, report) {
+  /** @type {BadPatient[]} */
   let badPatientsList = []
 
   console.log(`Comparing reports for ${referenceReport.measure}`);
@@ -66,20 +110,22 @@ function compareMeasureReports(referenceReport, report) {
       let missingPatients = referencePatientNames.filter((patientName) => { return !patientNames.includes(patientName) });
       let unexpectedPatients = patientNames.filter((patientName) => { return !referencePatientNames.includes(patientName) });
 
+      // log patients that are missing in the report
       console.log(`      Expected ${referencePatientNames.length} - Actual ${patientNames.length}`);
       missingPatients.forEach(patientName => {
         console.log(`        MISSING    ${patientName}`);
         addBadPatientEntry(badPatientsList, patientName, `Missing from ${referenceGroup.id} - ${referencePopulation.code.coding[0].display}`)
       });
+
+      // log patients that were unexpected in the report
       unexpectedPatients.forEach(patientName => {
         console.log(`        UNEXPECTED ${patientName}`);
         addBadPatientEntry(badPatientsList, patientName, `Unexpected in ${referenceGroup.id} - ${referencePopulation.code.coding[0].display}`)
       });
-      // build list of patients and their membership as we do this
     });
   });
 
-  // return list of patients
+  // return list of patients with issues
   return badPatientsList;
 }
 

--- a/travis/measureReportCompare.js
+++ b/travis/measureReportCompare.js
@@ -49,8 +49,15 @@ function compareMeasureReports(referenceReport, report) {
       // grab lists of patients
       let referenceList = grabReferencedResource(referencePopulation.subjectResults.reference, referenceReport);
       let list = grabReferencedResource(population.subjectResults.reference, report);
+
+      // Turn into list of patient names from reference report
       let referencePatientNames = referenceList.entry.map((entry) => { return entry.item.display; });
-      let patientNames = list.entry.map((entry) => { return entry.item.display; });
+
+      // Turn into list of patient names from calculated report. default to [] if list is empty/nonexistent
+      let patientNames = [];
+      if (list.entry) {
+        patientNames = list.entry.map((entry) => { return entry.item.display; });
+      }
 
       // compare lists
       let missingPatients = referencePatientNames.filter((patientName) => { return !patientNames.includes(patientName) });

--- a/travis/rebuild_bundles.sh
+++ b/travis/rebuild_bundles.sh
@@ -7,7 +7,7 @@ rebuild_log=./travis/tooling/rebuildRun.log
 rm ./fhir4/input/resources/measure/measure-EXM165_FHIR4-8.5.000.json
 rm ./fhir4/input/pagecontent/cql/EXM165_FHIR4-8.5.000.cql
 
-java -jar $tooling_jar -RefreshIG -ip="./fhir4/" -iv=fhir4 -t -d -p -v 2>&1 | tee $rebuild_log
+java -jar $tooling_jar -RefreshIG -ip="./fhir4/" -iv=fhir4 -t -d -p -v 2>&1 -fs http://localhost:8080/cqf-ruler-r4/fhir | tee $rebuild_log
 
 if grep -q '^0 Measures failed refresh' $rebuild_log && grep -q '^0 Measures refreshed, but not bundled' $rebuild_log; then
   echo "Bundle rebuild appears to be successful"

--- a/travis/rebuild_bundles.sh
+++ b/travis/rebuild_bundles.sh
@@ -7,7 +7,7 @@ rebuild_log=./travis/tooling/rebuildRun.log
 rm ./fhir4/input/resources/measure/measure-EXM165_FHIR4-8.5.000.json
 rm ./fhir4/input/pagecontent/cql/EXM165_FHIR4-8.5.000.cql
 
-java -jar $tooling_jar -RefreshIG -ip="./fhir4/" -iv=fhir4 -t -d -p -v 2>&1 -fs http://localhost:8080/cqf-ruler-r4/fhir | tee $rebuild_log
+java -jar $tooling_jar -RefreshIG -ip="./fhir4/" -iv=fhir4 -t -d -v 2>&1 -fs http://localhost:8080/cqf-ruler-r4/fhir | tee $rebuild_log
 
 if grep -q '^0 Measures failed refresh' $rebuild_log && grep -q '^0 Measures refreshed, but not bundled' $rebuild_log; then
   echo "Bundle rebuild appears to be successful"

--- a/travis/reset.sh
+++ b/travis/reset.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 docker kill cqf-ruler
-rm ./fhir-patient-generator/.new-cqf-ruler
+

--- a/travis/reset.sh
+++ b/travis/reset.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+docker kill cqf-ruler
+rm ./fhir-patient-generator/.new-cqf-ruler

--- a/travis/setup.sh
+++ b/travis/setup.sh
@@ -7,8 +7,8 @@ echo "> Fetching CQF-tooling JAR"
 ./travis/download_cqf_tooling.sh
 
 echo "> Setting Up cqf-ruler docker instance"
-docker pull contentgroup/cqf-ruler:develop
-docker run --name cqf-ruler --rm -dit -p 8080:8080 contentgroup/cqf-ruler:develop
+docker pull tacoma/cg-cqf-ruler:created-4.20.20
+docker run --name cqf-ruler --rm -dit -p 8080:8080 tacoma/cg-cqf-ruler:created-4.20.20
 
 echo "> Waiting for cqf-ruler to start up"
 until `curl --output /dev/null --silent --head --fail http://localhost:8080/cqf-ruler-r4`; do printf '.'; sleep 5; done

--- a/travis/setup.sh
+++ b/travis/setup.sh
@@ -7,6 +7,15 @@ echo "> Fetching CQF-tooling JAR"
 ./travis/download_cqf_tooling.sh
 
 echo "> Setting Up cqf-ruler docker instance"
-cd fhir-patient-generator
-make .new-cqf-ruler
-make .wait-cqf-ruler
+docker pull contentgroup/cqf-ruler:develop
+docker run --name cqf-ruler --rm -dit -p 8080:8080 contentgroup/cqf-ruler:develop
+
+echo "> Waiting for cqf-ruler to start up"
+until `curl --output /dev/null --silent --head --fail http://localhost:8080/cqf-ruler-r4`; do printf '.'; sleep 5; done
+
+# grab the status code and error the setup if it isn't 200
+statusCode=`curl -s -o /dev/null -L -I -w "%{http_code}" http://localhost:8080/cqf-ruler-r4`
+if [[ "$statusCode" != "200" ]]; then
+  echo "X cqf-ruler has failed to start up properly"
+  exit 1
+fi

--- a/travis/setup.sh
+++ b/travis/setup.sh
@@ -3,7 +3,6 @@
 echo "> Cloning FHIR Generated Patients..."
 git clone https://github.com/projecttacoma/fhir-patient-generator.git
 
-
 echo "> Fetching CQF-tooling JAR"
 ./travis/download_cqf_tooling.sh
 

--- a/travis/setup.sh
+++ b/travis/setup.sh
@@ -3,6 +3,11 @@
 echo "> Cloning FHIR Generated Patients..."
 git clone https://github.com/projecttacoma/fhir-patient-generator.git
 
+
 echo "> Fetching CQF-tooling JAR"
 ./travis/download_cqf_tooling.sh
 
+echo "> Setting Up cqf-ruler docker instance"
+cd fhir-patient-generator
+make .new-cqf-ruler
+make .wait-cqf-ruler

--- a/travis/setup.sh
+++ b/travis/setup.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 echo "> Cloning FHIR Generated Patients..."
-git clone --single-branch --branch measure-reports-regen https://github.com/projecttacoma/fhir-patient-generator.git
+git clone --single-branch --branch master https://github.com/projecttacoma/fhir-patient-generator.git
 
 echo "> Fetching CQF-tooling JAR"
 ./travis/download_cqf_tooling.sh

--- a/travis/setup.sh
+++ b/travis/setup.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 echo "> Cloning FHIR Generated Patients..."
-git clone https://github.com/projecttacoma/fhir-patient-generator.git
+git clone --single-branch --branch measure-reports-regen https://github.com/projecttacoma/fhir-patient-generator.git
 
 echo "> Fetching CQF-tooling JAR"
 ./travis/download_cqf_tooling.sh

--- a/travis/testDataHelpers.js
+++ b/travis/testDataHelpers.js
@@ -1,0 +1,108 @@
+const fs = require('fs');
+const process = require('process');
+const fhirInteractions = require('./fhirInteractions');
+
+/**
+ * Information about the test data available for a measure.
+ * 
+ * @typedef {Object} TestMeasureInfo
+ * @property {String} exmId - The EXM ID of the measure. ex. EXM_104
+ * @property {String} path - Path to the folder of test data.
+ * @property {String} measureReportPath - Path to the reference MeasureReport json file that should be compared against.
+ */
+
+/**
+ * Grabs the list of measures that fhir-patient-generator has test data for.
+ * 
+ * @returns {Promise<TestMeasureInfo[]>} List of information about each available test measure data.
+ */
+async function getTestMeasureList() {
+  // Find applicable measure test data directories in fhir-patient-generator
+  let fpgDir = fs.readdirSync('./fhir-patient-generator/')
+  let applicableMeasuresDirs = fpgDir.filter((dir) => { return dir.startsWith("EXM_") });
+
+  // Pull out applicable measure information on them
+  /** @type {TestMeasureInfo[]} */
+  let measureDirInfo = applicableMeasuresDirs.map((measureDir) => {
+    /** @type {TestMeasureInfo} */
+    let testDirInfo = {
+      exmId: measureDir,
+      path: `./fhir-patient-generator/${measureDir}/patients-r4`
+    };
+    let measureReportFile = fs.readdirSync(testDirInfo.path).find((filename) => { return filename.includes('measure-report.json')});
+    if (measureReportFile) {
+      testDirInfo.measureReportPath = `${testDirInfo.path}/${measureReportFile}`;
+    }
+    return testDirInfo;
+  });
+
+  return measureDirInfo;
+}
+
+/**
+ * Load all patient bundle in the test data folder. This will navigate into each "population" folder and load each bundle. Returns information about
+ * the paths of all resources put into cqf-ruler and their location so they may be removed later.
+ * 
+ * @param {String} testDataFolder Path to the folder of test data.
+ * @returns {BundleLoadInfo[]} Information about each loaded bundle.
+ */
+async function loadTestDataFolder(testDataFolder) {
+  // use data in all subfolders except for measure-reports. ex. numerator, denominator, etc.
+  let subfolders = fs.readdirSync(testDataFolder, { withFileTypes: true })
+    .filter((dir) => { return dir.isDirectory() && dir.name != 'measure-reports'})
+    .map((dir) => { return dir.name });
+
+  /** @type {BundleLoadInfo[]} */
+  let bundleResourceInfos = [];
+  // Iterate over sub folders
+  for (let subfolder of subfolders) {
+    let subfolderPath = testDataFolder + '/' + subfolder;
+    let patientBundles = fs.readdirSync(subfolderPath).filter((fileName) => { return fileName.endsWith(".json") });
+
+    // Iterate over bundles in this folder and post them to cqf-ruler
+    for (let patientBundleName of patientBundles) {
+      process.stdout.write('.');
+      //console.log(`Loading bundle ${subfolderPath}/${patientBundleName}`)
+      let newResourceInfo = await fhirInteractions.loadPatientBundle(`${subfolderPath}/${patientBundleName}`);
+      bundleResourceInfos.push(newResourceInfo);
+    }
+  }
+  console.log();
+
+  return bundleResourceInfos;
+}
+
+/**
+ * Delete all Resources from the list of information about bundles. This is used to clean up after a measure test to clean cqf-ruler
+ * for the next test. Each patient bundle is deleted individually, this is faster than trying to delete everything at one.
+ * 
+ * @param {BundleLoadInfo[]} bundleResourceInfos Information about the bundles that should be deleted.
+ */
+async function deleteBundleResources(bundleResourceInfos) {
+  for (let bundleResourceInfo of bundleResourceInfos) {
+    process.stdout.write('.');
+    //console.log("Deleting resources from " + bundleResourceInfo.originalBundle)
+    await fhirInteractions.deleteResources(bundleResourceInfo.resources);
+  }
+  console.log();
+}
+
+/**
+ * Loads the MeasureReport from that test data that will be used as reference.
+ * 
+ * @param {String} measureReportPath Path to the reference measure report.
+ * @returns {FHIR.MeasureReport} The MeasureReport resource that will be compared against.
+ */
+async function loadReferenceMeasureReport(measureReportPath) {
+  return new Promise((resolve, reject) => {
+    fs.readFile(measureReportPath, (err, data) => {
+      if (err) reject(err);
+      resolve(JSON.parse(data));
+    });
+  });
+}
+
+module.exports.getTestMeasureList = getTestMeasureList;
+module.exports.loadTestDataFolder = loadTestDataFolder;
+module.exports.deleteBundleResources = deleteBundleResources;
+module.exports.loadReferenceMeasureReport = loadReferenceMeasureReport;

--- a/travis/test_measures.sh
+++ b/travis/test_measures.sh
@@ -5,8 +5,5 @@ if ! ./travis/rebuild_bundles.sh; then
   exit 1
 fi
 
-# Use make commands to test measures and/or
-# compare calculation results against the
-# existing patient sets.
-
+echo "> Starting Calculation and Comparison of MeasureReports"
 node ./travis/calculateMeasures.js $1

--- a/travis/test_measures.sh
+++ b/travis/test_measures.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-echo "> Rebuilding Measure Bundles"
+echo "> Rebuilding Measure Bundles and Loading CQF-Ruler"
 if ! ./travis/rebuild_bundles.sh; then
   exit 1
 fi

--- a/travis/test_measures.sh
+++ b/travis/test_measures.sh
@@ -5,9 +5,10 @@ if ! ./travis/rebuild_bundles.sh; then
   exit 1
 fi
 
-cd fhir-patient-generator
-make all CI_TOOL=true
+#cd fhir-patient-generator
 
 # Use make commands to test measures and/or
 # compare calculation results against the
 # existing patient sets.
+
+node ./travis/calculateMeasures.js

--- a/travis/test_measures.sh
+++ b/travis/test_measures.sh
@@ -5,8 +5,6 @@ if ! ./travis/rebuild_bundles.sh; then
   exit 1
 fi
 
-#cd fhir-patient-generator
-
 # Use make commands to test measures and/or
 # compare calculation results against the
 # existing patient sets.

--- a/travis/test_measures.sh
+++ b/travis/test_measures.sh
@@ -11,4 +11,4 @@ fi
 # compare calculation results against the
 # existing patient sets.
 
-node ./travis/calculateMeasures.js
+node ./travis/calculateMeasures.js $1


### PR DESCRIPTION
Adds calculation and comparison of patient-list MeasureReports to the CI toolchain. Uses a Node JS script to load test data, retrieve MeasureReports from execution, compare MeasureReports and report results.

The Travis configuration makes use of environment variables to split the build by individual measures so they run as parallel jobs in the build.

These scripts can be run locally too. It's only two things you need to run. This may take around 1 hour and 40 minutes if you run every measure. Here is an overview of what they do:
 1. `./travis/setup.sh`
    - Clones `fhir-patient-generator`
    - Grabs the `cqf-tooling` jar.
    - Starts `cqf-ruler` and waits for it to be ready.
 2. `./travis/test_measures.sh`
    - Rebuilds measures and loads `cqf-ruler` measure bundles.
    - Loads test data for a measure, executes, compares MeasureReports, cleans up test data and repeats for each measure.
    - *NOTE:* To test only one measure just add the EXM id as an argument. ex. `./travis/test_measures.sh EXM_104`