### PR TITLE
Add measure version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # HL7 CMS/FHIR Connectathon
 
-Resources for use at HL7/CMS FHIR Connectathon, Clinical Reasoning Track.
+Resources for use at HL7/CMS FHIR Connectathon, Clinical Reasoning Track. 
 
 * [Track Description](https://confluence.hl7.org/display/FHIR/2020-05+Clinical+Reasoning)
 * [Zulip Stream](https://chat.fhir.org/#narrow/stream/179207-connectathon-mgmt/topic/Clinical.20Reasoning.20Track)
 
 * CQF-Ruler Docker Container:
 
-Select a Docker Container that is appropriate for the verion of FHIR you are working with:
+Select a Docker Container that is appropriate for the version of FHIR you are working with:
 
 DSTU3/R4
 ```
@@ -24,8 +24,8 @@ docker run -p 8080:8080 contentgroup/cqf-ruler:develop
 * Sandbox:
 
 http://cqm-sandbox.alphora.com/cqf-ruler-r4/fhir/
-The sandbox will be using the contentgroup/cqf-ruler:develop Docker Container which is approprioate for FHIR R4.0.1 work.
-A sandbox willl not be provided for FHIR3 or FHIR4.  Please use the appropriate container to host your own instance.
+The sandbox will be using the contentgroup/cqf-ruler:develop Docker Container which is appropriate for FHIR R4.0.1 work.
+A sandbox will not be provided for FHIR3 or FHIR4.  Please use the appropriate container to host your own instance.
 
 ## Measure Reporting Scenarios
 ```

--- a/fhir401/bundles/EXM104-9.1.000/EXM104-9.1.000-bundle.json
+++ b/fhir401/bundles/EXM104-9.1.000/EXM104-9.1.000-bundle.json
@@ -1755,19 +1755,19 @@
         "relatedArtifact": [
           {
             "type": "depends-on",
-            "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-FHIRHelpers|4.0.1"
+            "resource": "Library/library-FHIRHelpers-4.0.1"
           },
           {
             "type": "depends-on",
-            "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-MATGlobalCommonFunctions|5.0.000"
+            "resource": "Library/library-MATGlobalCommonFunctions-5.0.000"
           },
           {
             "type": "depends-on",
-            "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-SupplementalDataElements|2.0.0"
+            "resource": "Library/library-SupplementalDataElements-2.0.0"
           },
           {
             "type": "depends-on",
-            "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-TJCOverall|5.0.000"
+            "resource": "Library/library-TJCOverall-5.0.000"
           }
         ],
         "dataRequirement": [
@@ -2399,7 +2399,7 @@
         "relatedArtifact": [
           {
             "type": "depends-on",
-            "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-FHIRHelpers|4.0.1"
+            "resource": "Library/library-FHIRHelpers-4.0.1"
           }
         ],
         "dataRequirement": [
@@ -4318,7 +4318,7 @@
         "relatedArtifact": [
           {
             "type": "depends-on",
-            "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-FHIRHelpers|4.0.1"
+            "resource": "Library/library-FHIRHelpers-4.0.1"
           }
         ],
         "dataRequirement": [
@@ -4450,15 +4450,15 @@
         "relatedArtifact": [
           {
             "type": "depends-on",
-            "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-FHIRHelpers|4.0.1"
+            "resource": "Library/library-FHIRHelpers-4.0.1"
           },
           {
             "type": "depends-on",
-            "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-MATGlobalCommonFunctions|5.0.000"
+            "resource": "Library/library-MATGlobalCommonFunctions-5.0.000"
           },
           {
             "type": "depends-on",
-            "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-SupplementalDataElements|2.0.0"
+            "resource": "Library/library-SupplementalDataElements-2.0.0"
           }
         ],
         "dataRequirement": [

--- a/fhir401/bundles/EXM104-9.1.000/EXM104-9.1.000-files/library-EXM104-9.1.000.json
+++ b/fhir401/bundles/EXM104-9.1.000/EXM104-9.1.000-files/library-EXM104-9.1.000.json
@@ -52,19 +52,19 @@
   "relatedArtifact": [
     {
       "type": "depends-on",
-      "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-FHIRHelpers|4.0.1"
+      "resource": "Library/library-FHIRHelpers-4.0.1"
     },
     {
       "type": "depends-on",
-      "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-MATGlobalCommonFunctions|5.0.000"
+      "resource": "Library/library-MATGlobalCommonFunctions-5.0.000"
     },
     {
       "type": "depends-on",
-      "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-SupplementalDataElements|2.0.0"
+      "resource": "Library/library-SupplementalDataElements-2.0.0"
     },
     {
       "type": "depends-on",
-      "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-TJCOverall|5.0.000"
+      "resource": "Library/library-TJCOverall-5.0.000"
     }
   ],
   "dataRequirement": [

--- a/fhir401/bundles/EXM104-9.1.000/EXM104-9.1.000-files/library-deps-EXM104-9.1.000-bundle.json
+++ b/fhir401/bundles/EXM104-9.1.000/EXM104-9.1.000-files/library-deps-EXM104-9.1.000-bundle.json
@@ -58,7 +58,7 @@
         "relatedArtifact": [
           {
             "type": "depends-on",
-            "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-FHIRHelpers|4.0.1"
+            "resource": "Library/library-FHIRHelpers-4.0.1"
           }
         ],
         "dataRequirement": [
@@ -190,15 +190,15 @@
         "relatedArtifact": [
           {
             "type": "depends-on",
-            "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-FHIRHelpers|4.0.1"
+            "resource": "Library/library-FHIRHelpers-4.0.1"
           },
           {
             "type": "depends-on",
-            "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-MATGlobalCommonFunctions|5.0.000"
+            "resource": "Library/library-MATGlobalCommonFunctions-5.0.000"
           },
           {
             "type": "depends-on",
-            "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-SupplementalDataElements|2.0.0"
+            "resource": "Library/library-SupplementalDataElements-2.0.0"
           }
         ],
         "dataRequirement": [
@@ -304,7 +304,7 @@
         "relatedArtifact": [
           {
             "type": "depends-on",
-            "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-FHIRHelpers|4.0.1"
+            "resource": "Library/library-FHIRHelpers-4.0.1"
           }
         ],
         "dataRequirement": [

--- a/fhir401/bundles/EXM105-9.1.000/EXM105-9.1.000-bundle.json
+++ b/fhir401/bundles/EXM105-9.1.000/EXM105-9.1.000-bundle.json
@@ -2726,7 +2726,7 @@
         "relatedArtifact": [
           {
             "type": "depends-on",
-            "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-FHIRHelpers|4.0.1"
+            "resource": "Library/library-FHIRHelpers-4.0.1"
           }
         ],
         "dataRequirement": [
@@ -2811,19 +2811,19 @@
         "relatedArtifact": [
           {
             "type": "depends-on",
-            "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-FHIRHelpers|4.0.1"
+            "resource": "Library/library-FHIRHelpers-4.0.1"
           },
           {
             "type": "depends-on",
-            "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-MATGlobalCommonFunctions|5.0.000"
+            "resource": "Library/library-MATGlobalCommonFunctions-5.0.000"
           },
           {
             "type": "depends-on",
-            "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-SupplementalDataElements|2.0.0"
+            "resource": "Library/library-SupplementalDataElements-2.0.0"
           },
           {
             "type": "depends-on",
-            "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-TJCOverall|5.0.000"
+            "resource": "Library/library-TJCOverall-5.0.000"
           }
         ],
         "dataRequirement": [
@@ -4089,7 +4089,7 @@
         "relatedArtifact": [
           {
             "type": "depends-on",
-            "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-FHIRHelpers|4.0.1"
+            "resource": "Library/library-FHIRHelpers-4.0.1"
           }
         ],
         "dataRequirement": [
@@ -4221,15 +4221,15 @@
         "relatedArtifact": [
           {
             "type": "depends-on",
-            "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-FHIRHelpers|4.0.1"
+            "resource": "Library/library-FHIRHelpers-4.0.1"
           },
           {
             "type": "depends-on",
-            "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-MATGlobalCommonFunctions|5.0.000"
+            "resource": "Library/library-MATGlobalCommonFunctions-5.0.000"
           },
           {
             "type": "depends-on",
-            "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-SupplementalDataElements|2.0.0"
+            "resource": "Library/library-SupplementalDataElements-2.0.0"
           }
         ],
         "dataRequirement": [

--- a/fhir401/bundles/EXM105-9.1.000/EXM105-9.1.000-files/library-EXM105-9.1.000.json
+++ b/fhir401/bundles/EXM105-9.1.000/EXM105-9.1.000-files/library-EXM105-9.1.000.json
@@ -52,19 +52,19 @@
   "relatedArtifact": [
     {
       "type": "depends-on",
-      "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-FHIRHelpers|4.0.1"
+      "resource": "Library/library-FHIRHelpers-4.0.1"
     },
     {
       "type": "depends-on",
-      "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-MATGlobalCommonFunctions|5.0.000"
+      "resource": "Library/library-MATGlobalCommonFunctions-5.0.000"
     },
     {
       "type": "depends-on",
-      "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-SupplementalDataElements|2.0.0"
+      "resource": "Library/library-SupplementalDataElements-2.0.0"
     },
     {
       "type": "depends-on",
-      "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-TJCOverall|5.0.000"
+      "resource": "Library/library-TJCOverall-5.0.000"
     }
   ],
   "dataRequirement": [

--- a/fhir401/bundles/EXM105-9.1.000/EXM105-9.1.000-files/library-deps-EXM105-9.1.000-bundle.json
+++ b/fhir401/bundles/EXM105-9.1.000/EXM105-9.1.000-files/library-deps-EXM105-9.1.000-bundle.json
@@ -58,7 +58,7 @@
         "relatedArtifact": [
           {
             "type": "depends-on",
-            "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-FHIRHelpers|4.0.1"
+            "resource": "Library/library-FHIRHelpers-4.0.1"
           }
         ],
         "dataRequirement": [
@@ -190,15 +190,15 @@
         "relatedArtifact": [
           {
             "type": "depends-on",
-            "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-FHIRHelpers|4.0.1"
+            "resource": "Library/library-FHIRHelpers-4.0.1"
           },
           {
             "type": "depends-on",
-            "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-MATGlobalCommonFunctions|5.0.000"
+            "resource": "Library/library-MATGlobalCommonFunctions-5.0.000"
           },
           {
             "type": "depends-on",
-            "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-SupplementalDataElements|2.0.0"
+            "resource": "Library/library-SupplementalDataElements-2.0.0"
           }
         ],
         "dataRequirement": [
@@ -304,7 +304,7 @@
         "relatedArtifact": [
           {
             "type": "depends-on",
-            "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-FHIRHelpers|4.0.1"
+            "resource": "Library/library-FHIRHelpers-4.0.1"
           }
         ],
         "dataRequirement": [

--- a/fhir401/bundles/EXM108-9.2.000/EXM108-9.2.000-bundle.json
+++ b/fhir401/bundles/EXM108-9.2.000/EXM108-9.2.000-bundle.json
@@ -154,11 +154,11 @@
         "relatedArtifact": [
           {
             "type": "depends-on",
-            "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-FHIRHelpers|4.0.1"
+            "resource": "Library/library-FHIRHelpers-4.0.1"
           },
           {
             "type": "depends-on",
-            "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-MATGlobalCommonFunctions|5.0.000"
+            "resource": "Library/library-MATGlobalCommonFunctions-5.0.000"
           }
         ],
         "content": [
@@ -264,23 +264,23 @@
         "relatedArtifact": [
           {
             "type": "depends-on",
-            "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-FHIRHelpers|4.0.1"
+            "resource": "Library/library-FHIRHelpers-4.0.1"
           },
           {
             "type": "depends-on",
-            "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-MATGlobalCommonFunctions|5.0.000"
+            "resource": "Library/library-MATGlobalCommonFunctions-5.0.000"
           },
           {
             "type": "depends-on",
-            "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-SupplementalDataElements|2.0.0"
+            "resource": "Library/library-SupplementalDataElements-2.0.0"
           },
           {
             "type": "depends-on",
-            "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-VTEICU|5.0.000"
+            "resource": "Library/library-VTEICU-5.0.000"
           },
           {
             "type": "depends-on",
-            "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-TJCOverall|5.0.000"
+            "resource": "Library/library-TJCOverall-5.0.000"
           }
         ],
         "dataRequirement": [
@@ -18096,7 +18096,7 @@
         "relatedArtifact": [
           {
             "type": "depends-on",
-            "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-FHIRHelpers|4.0.1"
+            "resource": "Library/library-FHIRHelpers-4.0.1"
           }
         ],
         "dataRequirement": [
@@ -31448,7 +31448,7 @@
         "relatedArtifact": [
           {
             "type": "depends-on",
-            "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-FHIRHelpers|4.0.1"
+            "resource": "Library/library-FHIRHelpers-4.0.1"
           }
         ],
         "dataRequirement": [
@@ -31580,15 +31580,15 @@
         "relatedArtifact": [
           {
             "type": "depends-on",
-            "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-FHIRHelpers|4.0.1"
+            "resource": "Library/library-FHIRHelpers-4.0.1"
           },
           {
             "type": "depends-on",
-            "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-MATGlobalCommonFunctions|5.0.000"
+            "resource": "Library/library-MATGlobalCommonFunctions-5.0.000"
           },
           {
             "type": "depends-on",
-            "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-SupplementalDataElements|2.0.0"
+            "resource": "Library/library-SupplementalDataElements-2.0.0"
           }
         ],
         "dataRequirement": [

--- a/fhir401/bundles/EXM108-9.2.000/EXM108-9.2.000-files/library-EXM108-9.2.000.json
+++ b/fhir401/bundles/EXM108-9.2.000/EXM108-9.2.000-files/library-EXM108-9.2.000.json
@@ -52,23 +52,23 @@
   "relatedArtifact": [
     {
       "type": "depends-on",
-      "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-FHIRHelpers|4.0.1"
+      "resource": "Library/library-FHIRHelpers-4.0.1"
     },
     {
       "type": "depends-on",
-      "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-MATGlobalCommonFunctions|5.0.000"
+      "resource": "Library/library-MATGlobalCommonFunctions-5.0.000"
     },
     {
       "type": "depends-on",
-      "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-SupplementalDataElements|2.0.0"
+      "resource": "Library/library-SupplementalDataElements-2.0.0"
     },
     {
       "type": "depends-on",
-      "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-VTEICU|5.0.000"
+      "resource": "Library/library-VTEICU-5.0.000"
     },
     {
       "type": "depends-on",
-      "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-TJCOverall|5.0.000"
+      "resource": "Library/library-TJCOverall-5.0.000"
     }
   ],
   "dataRequirement": [

--- a/fhir401/bundles/EXM108-9.2.000/EXM108-9.2.000-files/library-deps-EXM108-9.2.000-bundle.json
+++ b/fhir401/bundles/EXM108-9.2.000/EXM108-9.2.000-files/library-deps-EXM108-9.2.000-bundle.json
@@ -58,11 +58,11 @@
         "relatedArtifact": [
           {
             "type": "depends-on",
-            "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-FHIRHelpers|4.0.1"
+            "resource": "Library/library-FHIRHelpers-4.0.1"
           },
           {
             "type": "depends-on",
-            "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-MATGlobalCommonFunctions|5.0.000"
+            "resource": "Library/library-MATGlobalCommonFunctions-5.0.000"
           }
         ],
         "content": [
@@ -136,7 +136,7 @@
         "relatedArtifact": [
           {
             "type": "depends-on",
-            "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-FHIRHelpers|4.0.1"
+            "resource": "Library/library-FHIRHelpers-4.0.1"
           }
         ],
         "dataRequirement": [
@@ -268,15 +268,15 @@
         "relatedArtifact": [
           {
             "type": "depends-on",
-            "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-FHIRHelpers|4.0.1"
+            "resource": "Library/library-FHIRHelpers-4.0.1"
           },
           {
             "type": "depends-on",
-            "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-MATGlobalCommonFunctions|5.0.000"
+            "resource": "Library/library-MATGlobalCommonFunctions-5.0.000"
           },
           {
             "type": "depends-on",
-            "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-SupplementalDataElements|2.0.0"
+            "resource": "Library/library-SupplementalDataElements-2.0.0"
           }
         ],
         "dataRequirement": [
@@ -382,7 +382,7 @@
         "relatedArtifact": [
           {
             "type": "depends-on",
-            "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-FHIRHelpers|4.0.1"
+            "resource": "Library/library-FHIRHelpers-4.0.1"
           }
         ],
         "dataRequirement": [

--- a/fhir401/bundles/EXM124-9.0.000/EXM124-9.0.000-bundle.json
+++ b/fhir401/bundles/EXM124-9.0.000/EXM124-9.0.000-bundle.json
@@ -311,11 +311,11 @@
         "relatedArtifact": [
           {
             "type": "depends-on",
-            "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-MATGlobalCommonFunctions|5.0.000"
+            "resource": "Library/library-MATGlobalCommonFunctions-5.0.000"
           },
           {
             "type": "depends-on",
-            "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-FHIRHelpers|4.0.1"
+            "resource": "Library/library-FHIRHelpers-4.0.1"
           }
         ],
         "dataRequirement": [
@@ -1776,7 +1776,7 @@
         "relatedArtifact": [
           {
             "type": "depends-on",
-            "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-FHIRHelpers|4.0.1"
+            "resource": "Library/library-FHIRHelpers-4.0.1"
           }
         ],
         "dataRequirement": [
@@ -3087,7 +3087,7 @@
         "relatedArtifact": [
           {
             "type": "depends-on",
-            "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-FHIRHelpers|4.0.1"
+            "resource": "Library/library-FHIRHelpers-4.0.1"
           }
         ],
         "dataRequirement": [
@@ -3332,7 +3332,7 @@
         "relatedArtifact": [
           {
             "type": "depends-on",
-            "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-FHIRHelpers|4.0.1"
+            "resource": "Library/library-FHIRHelpers-4.0.1"
           }
         ],
         "dataRequirement": [
@@ -3525,23 +3525,23 @@
         "relatedArtifact": [
           {
             "type": "depends-on",
-            "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-FHIRHelpers|4.0.1"
+            "resource": "Library/library-FHIRHelpers-4.0.1"
           },
           {
             "type": "depends-on",
-            "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-Hospice|2.0.000"
+            "resource": "Library/library-Hospice-2.0.000"
           },
           {
             "type": "depends-on",
-            "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-AdultOutpatientEncounters|2.0.000"
+            "resource": "Library/library-AdultOutpatientEncounters-2.0.000"
           },
           {
             "type": "depends-on",
-            "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-MATGlobalCommonFunctions|5.0.000"
+            "resource": "Library/library-MATGlobalCommonFunctions-5.0.000"
           },
           {
             "type": "depends-on",
-            "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-SupplementalDataElements|2.0.0"
+            "resource": "Library/library-SupplementalDataElements-2.0.0"
           }
         ],
         "dataRequirement": [

--- a/fhir401/bundles/EXM124-9.0.000/EXM124-9.0.000-files/library-EXM124-9.0.000.json
+++ b/fhir401/bundles/EXM124-9.0.000/EXM124-9.0.000-files/library-EXM124-9.0.000.json
@@ -52,23 +52,23 @@
   "relatedArtifact": [
     {
       "type": "depends-on",
-      "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-FHIRHelpers|4.0.1"
+      "resource": "Library/library-FHIRHelpers-4.0.1"
     },
     {
       "type": "depends-on",
-      "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-Hospice|2.0.000"
+      "resource": "Library/library-Hospice-2.0.000"
     },
     {
       "type": "depends-on",
-      "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-AdultOutpatientEncounters|2.0.000"
+      "resource": "Library/library-AdultOutpatientEncounters-2.0.000"
     },
     {
       "type": "depends-on",
-      "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-MATGlobalCommonFunctions|5.0.000"
+      "resource": "Library/library-MATGlobalCommonFunctions-5.0.000"
     },
     {
       "type": "depends-on",
-      "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-SupplementalDataElements|2.0.0"
+      "resource": "Library/library-SupplementalDataElements-2.0.0"
     }
   ],
   "dataRequirement": [

--- a/fhir401/bundles/EXM124-9.0.000/EXM124-9.0.000-files/library-deps-EXM124-9.0.000-bundle.json
+++ b/fhir401/bundles/EXM124-9.0.000/EXM124-9.0.000-files/library-deps-EXM124-9.0.000-bundle.json
@@ -58,11 +58,11 @@
         "relatedArtifact": [
           {
             "type": "depends-on",
-            "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-MATGlobalCommonFunctions|5.0.000"
+            "resource": "Library/library-MATGlobalCommonFunctions-5.0.000"
           },
           {
             "type": "depends-on",
-            "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-FHIRHelpers|4.0.1"
+            "resource": "Library/library-FHIRHelpers-4.0.1"
           }
         ],
         "dataRequirement": [
@@ -165,7 +165,7 @@
         "relatedArtifact": [
           {
             "type": "depends-on",
-            "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-FHIRHelpers|4.0.1"
+            "resource": "Library/library-FHIRHelpers-4.0.1"
           }
         ],
         "dataRequirement": [
@@ -297,7 +297,7 @@
         "relatedArtifact": [
           {
             "type": "depends-on",
-            "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-FHIRHelpers|4.0.1"
+            "resource": "Library/library-FHIRHelpers-4.0.1"
           }
         ],
         "dataRequirement": [
@@ -418,7 +418,7 @@
         "relatedArtifact": [
           {
             "type": "depends-on",
-            "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-FHIRHelpers|4.0.1"
+            "resource": "Library/library-FHIRHelpers-4.0.1"
           }
         ],
         "dataRequirement": [

--- a/fhir401/bundles/EXM125-8.0.000/EXM125-8.0.000-bundle.json
+++ b/fhir401/bundles/EXM125-8.0.000/EXM125-8.0.000-bundle.json
@@ -903,11 +903,11 @@
         "relatedArtifact": [
           {
             "type": "depends-on",
-            "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-MATGlobalCommonFunctions|5.0.000"
+            "resource": "Library/library-MATGlobalCommonFunctions-5.0.000"
           },
           {
             "type": "depends-on",
-            "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-FHIRHelpers|4.0.1"
+            "resource": "Library/library-FHIRHelpers-4.0.1"
           }
         ],
         "dataRequirement": [
@@ -1010,23 +1010,23 @@
         "relatedArtifact": [
           {
             "type": "depends-on",
-            "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-FHIRHelpers|4.0.1"
+            "resource": "Library/library-FHIRHelpers-4.0.1"
           },
           {
             "type": "depends-on",
-            "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-Hospice|2.0.000"
+            "resource": "Library/library-Hospice-2.0.000"
           },
           {
             "type": "depends-on",
-            "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-AdultOutpatientEncounters|2.0.000"
+            "resource": "Library/library-AdultOutpatientEncounters-2.0.000"
           },
           {
             "type": "depends-on",
-            "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-MATGlobalCommonFunctions|5.0.000"
+            "resource": "Library/library-MATGlobalCommonFunctions-5.0.000"
           },
           {
             "type": "depends-on",
-            "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-SupplementalDataElements|2.0.0"
+            "resource": "Library/library-SupplementalDataElements-2.0.0"
           }
         ],
         "dataRequirement": [
@@ -2009,7 +2009,7 @@
         "relatedArtifact": [
           {
             "type": "depends-on",
-            "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-FHIRHelpers|4.0.1"
+            "resource": "Library/library-FHIRHelpers-4.0.1"
           }
         ],
         "dataRequirement": [
@@ -3358,7 +3358,7 @@
         "relatedArtifact": [
           {
             "type": "depends-on",
-            "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-FHIRHelpers|4.0.1"
+            "resource": "Library/library-FHIRHelpers-4.0.1"
           }
         ],
         "dataRequirement": [
@@ -3534,7 +3534,7 @@
         "relatedArtifact": [
           {
             "type": "depends-on",
-            "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-FHIRHelpers|4.0.1"
+            "resource": "Library/library-FHIRHelpers-4.0.1"
           }
         ],
         "dataRequirement": [

--- a/fhir401/bundles/EXM125-8.0.000/EXM125-8.0.000-files/library-EXM125-8.0.000.json
+++ b/fhir401/bundles/EXM125-8.0.000/EXM125-8.0.000-files/library-EXM125-8.0.000.json
@@ -52,23 +52,23 @@
   "relatedArtifact": [
     {
       "type": "depends-on",
-      "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-FHIRHelpers|4.0.1"
+      "resource": "Library/library-FHIRHelpers-4.0.1"
     },
     {
       "type": "depends-on",
-      "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-Hospice|2.0.000"
+      "resource": "Library/library-Hospice-2.0.000"
     },
     {
       "type": "depends-on",
-      "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-AdultOutpatientEncounters|2.0.000"
+      "resource": "Library/library-AdultOutpatientEncounters-2.0.000"
     },
     {
       "type": "depends-on",
-      "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-MATGlobalCommonFunctions|5.0.000"
+      "resource": "Library/library-MATGlobalCommonFunctions-5.0.000"
     },
     {
       "type": "depends-on",
-      "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-SupplementalDataElements|2.0.0"
+      "resource": "Library/library-SupplementalDataElements-2.0.0"
     }
   ],
   "dataRequirement": [

--- a/fhir401/bundles/EXM125-8.0.000/EXM125-8.0.000-files/library-deps-EXM125-8.0.000-bundle.json
+++ b/fhir401/bundles/EXM125-8.0.000/EXM125-8.0.000-files/library-deps-EXM125-8.0.000-bundle.json
@@ -58,11 +58,11 @@
         "relatedArtifact": [
           {
             "type": "depends-on",
-            "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-MATGlobalCommonFunctions|5.0.000"
+            "resource": "Library/library-MATGlobalCommonFunctions-5.0.000"
           },
           {
             "type": "depends-on",
-            "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-FHIRHelpers|4.0.1"
+            "resource": "Library/library-FHIRHelpers-4.0.1"
           }
         ],
         "dataRequirement": [
@@ -165,7 +165,7 @@
         "relatedArtifact": [
           {
             "type": "depends-on",
-            "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-FHIRHelpers|4.0.1"
+            "resource": "Library/library-FHIRHelpers-4.0.1"
           }
         ],
         "dataRequirement": [
@@ -297,7 +297,7 @@
         "relatedArtifact": [
           {
             "type": "depends-on",
-            "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-FHIRHelpers|4.0.1"
+            "resource": "Library/library-FHIRHelpers-4.0.1"
           }
         ],
         "dataRequirement": [
@@ -418,7 +418,7 @@
         "relatedArtifact": [
           {
             "type": "depends-on",
-            "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-FHIRHelpers|4.0.1"
+            "resource": "Library/library-FHIRHelpers-4.0.1"
           }
         ],
         "dataRequirement": [

--- a/fhir401/bundles/EXM130-8.0.000/EXM130-8.0.000-bundle.json
+++ b/fhir401/bundles/EXM130-8.0.000/EXM130-8.0.000-bundle.json
@@ -1239,11 +1239,11 @@
         "relatedArtifact": [
           {
             "type": "depends-on",
-            "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-MATGlobalCommonFunctions|5.0.000"
+            "resource": "Library/library-MATGlobalCommonFunctions-5.0.000"
           },
           {
             "type": "depends-on",
-            "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-FHIRHelpers|4.0.1"
+            "resource": "Library/library-FHIRHelpers-4.0.1"
           }
         ],
         "dataRequirement": [
@@ -2601,23 +2601,23 @@
         "relatedArtifact": [
           {
             "type": "depends-on",
-            "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-FHIRHelpers|4.0.1"
+            "resource": "Library/library-FHIRHelpers-4.0.1"
           },
           {
             "type": "depends-on",
-            "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-Hospice|2.0.000"
+            "resource": "Library/library-Hospice-2.0.000"
           },
           {
             "type": "depends-on",
-            "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-AdultOutpatientEncounters|2.0.000"
+            "resource": "Library/library-AdultOutpatientEncounters-2.0.000"
           },
           {
             "type": "depends-on",
-            "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-MATGlobalCommonFunctions|5.0.000"
+            "resource": "Library/library-MATGlobalCommonFunctions-5.0.000"
           },
           {
             "type": "depends-on",
-            "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-SupplementalDataElements|2.0.0"
+            "resource": "Library/library-SupplementalDataElements-2.0.0"
           }
         ],
         "dataRequirement": [
@@ -2885,7 +2885,7 @@
         "relatedArtifact": [
           {
             "type": "depends-on",
-            "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-FHIRHelpers|4.0.1"
+            "resource": "Library/library-FHIRHelpers-4.0.1"
           }
         ],
         "dataRequirement": [
@@ -3770,7 +3770,7 @@
         "relatedArtifact": [
           {
             "type": "depends-on",
-            "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-FHIRHelpers|4.0.1"
+            "resource": "Library/library-FHIRHelpers-4.0.1"
           }
         ],
         "dataRequirement": [
@@ -3946,7 +3946,7 @@
         "relatedArtifact": [
           {
             "type": "depends-on",
-            "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-FHIRHelpers|4.0.1"
+            "resource": "Library/library-FHIRHelpers-4.0.1"
           }
         ],
         "dataRequirement": [

--- a/fhir401/bundles/EXM130-8.0.000/EXM130-8.0.000-files/library-EXM130-8.0.000.json
+++ b/fhir401/bundles/EXM130-8.0.000/EXM130-8.0.000-files/library-EXM130-8.0.000.json
@@ -52,23 +52,23 @@
   "relatedArtifact": [
     {
       "type": "depends-on",
-      "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-FHIRHelpers|4.0.1"
+      "resource": "Library/library-FHIRHelpers-4.0.1"
     },
     {
       "type": "depends-on",
-      "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-Hospice|2.0.000"
+      "resource": "Library/library-Hospice-2.0.000"
     },
     {
       "type": "depends-on",
-      "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-AdultOutpatientEncounters|2.0.000"
+      "resource": "Library/library-AdultOutpatientEncounters-2.0.000"
     },
     {
       "type": "depends-on",
-      "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-MATGlobalCommonFunctions|5.0.000"
+      "resource": "Library/library-MATGlobalCommonFunctions-5.0.000"
     },
     {
       "type": "depends-on",
-      "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-SupplementalDataElements|2.0.0"
+      "resource": "Library/library-SupplementalDataElements-2.0.0"
     }
   ],
   "dataRequirement": [

--- a/fhir401/bundles/EXM130-8.0.000/EXM130-8.0.000-files/library-deps-EXM130-8.0.000-bundle.json
+++ b/fhir401/bundles/EXM130-8.0.000/EXM130-8.0.000-files/library-deps-EXM130-8.0.000-bundle.json
@@ -58,11 +58,11 @@
         "relatedArtifact": [
           {
             "type": "depends-on",
-            "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-MATGlobalCommonFunctions|5.0.000"
+            "resource": "Library/library-MATGlobalCommonFunctions-5.0.000"
           },
           {
             "type": "depends-on",
-            "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-FHIRHelpers|4.0.1"
+            "resource": "Library/library-FHIRHelpers-4.0.1"
           }
         ],
         "dataRequirement": [
@@ -165,7 +165,7 @@
         "relatedArtifact": [
           {
             "type": "depends-on",
-            "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-FHIRHelpers|4.0.1"
+            "resource": "Library/library-FHIRHelpers-4.0.1"
           }
         ],
         "dataRequirement": [
@@ -297,7 +297,7 @@
         "relatedArtifact": [
           {
             "type": "depends-on",
-            "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-FHIRHelpers|4.0.1"
+            "resource": "Library/library-FHIRHelpers-4.0.1"
           }
         ],
         "dataRequirement": [
@@ -418,7 +418,7 @@
         "relatedArtifact": [
           {
             "type": "depends-on",
-            "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-FHIRHelpers|4.0.1"
+            "resource": "Library/library-FHIRHelpers-4.0.1"
           }
         ],
         "dataRequirement": [

--- a/fhir401/bundles/EXM349-3.0.000/EXM349-3.0.000-bundle.json
+++ b/fhir401/bundles/EXM349-3.0.000/EXM349-3.0.000-bundle.json
@@ -240,15 +240,15 @@
         "relatedArtifact": [
           {
             "type": "depends-on",
-            "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-FHIRHelpers|4.0.1"
+            "resource": "Library/library-FHIRHelpers-4.0.1"
           },
           {
             "type": "depends-on",
-            "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-MATGlobalCommonFunctions|5.0.000"
+            "resource": "Library/library-MATGlobalCommonFunctions-5.0.000"
           },
           {
             "type": "depends-on",
-            "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-SupplementalDataElements|2.0.0"
+            "resource": "Library/library-SupplementalDataElements-2.0.0"
           }
         ],
         "dataRequirement": [
@@ -1685,7 +1685,7 @@
         "relatedArtifact": [
           {
             "type": "depends-on",
-            "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-FHIRHelpers|4.0.1"
+            "resource": "Library/library-FHIRHelpers-4.0.1"
           }
         ],
         "dataRequirement": [
@@ -2596,7 +2596,7 @@
         "relatedArtifact": [
           {
             "type": "depends-on",
-            "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-FHIRHelpers|4.0.1"
+            "resource": "Library/library-FHIRHelpers-4.0.1"
           }
         ],
         "dataRequirement": [

--- a/fhir401/bundles/EXM349-3.0.000/EXM349-3.0.000-files/library-EXM349-3.0.000.json
+++ b/fhir401/bundles/EXM349-3.0.000/EXM349-3.0.000-files/library-EXM349-3.0.000.json
@@ -52,15 +52,15 @@
   "relatedArtifact": [
     {
       "type": "depends-on",
-      "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-FHIRHelpers|4.0.1"
+      "resource": "Library/library-FHIRHelpers-4.0.1"
     },
     {
       "type": "depends-on",
-      "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-MATGlobalCommonFunctions|5.0.000"
+      "resource": "Library/library-MATGlobalCommonFunctions-5.0.000"
     },
     {
       "type": "depends-on",
-      "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-SupplementalDataElements|2.0.0"
+      "resource": "Library/library-SupplementalDataElements-2.0.0"
     }
   ],
   "dataRequirement": [

--- a/fhir401/bundles/EXM349-3.0.000/EXM349-3.0.000-files/library-deps-EXM349-3.0.000-bundle.json
+++ b/fhir401/bundles/EXM349-3.0.000/EXM349-3.0.000-files/library-deps-EXM349-3.0.000-bundle.json
@@ -58,7 +58,7 @@
         "relatedArtifact": [
           {
             "type": "depends-on",
-            "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-FHIRHelpers|4.0.1"
+            "resource": "Library/library-FHIRHelpers-4.0.1"
           }
         ],
         "dataRequirement": [
@@ -190,7 +190,7 @@
         "relatedArtifact": [
           {
             "type": "depends-on",
-            "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-FHIRHelpers|4.0.1"
+            "resource": "Library/library-FHIRHelpers-4.0.1"
           }
         ],
         "dataRequirement": [

--- a/fhir401/bundles/EXM506-3.0.000/EXM506-3.0.000-bundle.json
+++ b/fhir401/bundles/EXM506-3.0.000/EXM506-3.0.000-bundle.json
@@ -627,15 +627,15 @@
         "relatedArtifact": [
           {
             "type": "depends-on",
-            "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-MATGlobalCommonFunctions|5.0.000"
+            "resource": "Library/library-MATGlobalCommonFunctions-5.0.000"
           },
           {
             "type": "depends-on",
-            "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-FHIRHelpers|4.0.1"
+            "resource": "Library/library-FHIRHelpers-4.0.1"
           },
           {
             "type": "depends-on",
-            "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-SupplementalDataElements|2.0.0"
+            "resource": "Library/library-SupplementalDataElements-2.0.0"
           }
         ],
         "dataRequirement": [
@@ -19049,7 +19049,7 @@
         "relatedArtifact": [
           {
             "type": "depends-on",
-            "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-FHIRHelpers|4.0.1"
+            "resource": "Library/library-FHIRHelpers-4.0.1"
           }
         ],
         "dataRequirement": [
@@ -19971,7 +19971,7 @@
         "relatedArtifact": [
           {
             "type": "depends-on",
-            "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-FHIRHelpers|4.0.1"
+            "resource": "Library/library-FHIRHelpers-4.0.1"
           }
         ],
         "dataRequirement": [

--- a/fhir401/bundles/EXM506-3.0.000/EXM506-3.0.000-files/library-EXM506-3.0.000.json
+++ b/fhir401/bundles/EXM506-3.0.000/EXM506-3.0.000-files/library-EXM506-3.0.000.json
@@ -52,15 +52,15 @@
   "relatedArtifact": [
     {
       "type": "depends-on",
-      "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-MATGlobalCommonFunctions|5.0.000"
+      "resource": "Library/library-MATGlobalCommonFunctions-5.0.000"
     },
     {
       "type": "depends-on",
-      "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-FHIRHelpers|4.0.1"
+      "resource": "Library/library-FHIRHelpers-4.0.1"
     },
     {
       "type": "depends-on",
-      "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-SupplementalDataElements|2.0.0"
+      "resource": "Library/library-SupplementalDataElements-2.0.0"
     }
   ],
   "dataRequirement": [

--- a/fhir401/bundles/EXM506-3.0.000/EXM506-3.0.000-files/library-deps-EXM506-3.0.000-bundle.json
+++ b/fhir401/bundles/EXM506-3.0.000/EXM506-3.0.000-files/library-deps-EXM506-3.0.000-bundle.json
@@ -58,7 +58,7 @@
         "relatedArtifact": [
           {
             "type": "depends-on",
-            "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-FHIRHelpers|4.0.1"
+            "resource": "Library/library-FHIRHelpers-4.0.1"
           }
         ],
         "dataRequirement": [
@@ -190,7 +190,7 @@
         "relatedArtifact": [
           {
             "type": "depends-on",
-            "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-FHIRHelpers|4.0.1"
+            "resource": "Library/library-FHIRHelpers-4.0.1"
           }
         ],
         "dataRequirement": [

--- a/fhir401/bundles/EXM529-1.0.000/EXM529-1.0.000-bundle.json
+++ b/fhir401/bundles/EXM529-1.0.000/EXM529-1.0.000-bundle.json
@@ -1236,7 +1236,7 @@
         "relatedArtifact": [
           {
             "type": "depends-on",
-            "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-FHIRHelpers|4.0.1"
+            "resource": "Library/library-FHIRHelpers-4.0.1"
           }
         ],
         "dataRequirement": [
@@ -2144,7 +2144,7 @@
         "relatedArtifact": [
           {
             "type": "depends-on",
-            "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-FHIRHelpers|4.0.1"
+            "resource": "Library/library-FHIRHelpers-4.0.1"
           }
         ],
         "dataRequirement": [
@@ -2529,15 +2529,15 @@
         "relatedArtifact": [
           {
             "type": "depends-on",
-            "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-FHIRHelpers|4.0.1"
+            "resource": "Library/library-FHIRHelpers-4.0.1"
           },
           {
             "type": "depends-on",
-            "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-MATGlobalCommonFunctions|5.0.000"
+            "resource": "Library/library-MATGlobalCommonFunctions-5.0.000"
           },
           {
             "type": "depends-on",
-            "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-SupplementalDataElements|2.0.0"
+            "resource": "Library/library-SupplementalDataElements-2.0.0"
           }
         ],
         "dataRequirement": [

--- a/fhir401/bundles/EXM529-1.0.000/EXM529-1.0.000-files/library-EXM529-1.0.000.json
+++ b/fhir401/bundles/EXM529-1.0.000/EXM529-1.0.000-files/library-EXM529-1.0.000.json
@@ -52,15 +52,15 @@
   "relatedArtifact": [
     {
       "type": "depends-on",
-      "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-FHIRHelpers|4.0.1"
+      "resource": "Library/library-FHIRHelpers-4.0.1"
     },
     {
       "type": "depends-on",
-      "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-MATGlobalCommonFunctions|5.0.000"
+      "resource": "Library/library-MATGlobalCommonFunctions-5.0.000"
     },
     {
       "type": "depends-on",
-      "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-SupplementalDataElements|2.0.0"
+      "resource": "Library/library-SupplementalDataElements-2.0.0"
     }
   ],
   "dataRequirement": [

--- a/fhir401/bundles/EXM529-1.0.000/EXM529-1.0.000-files/library-deps-EXM529-1.0.000-bundle.json
+++ b/fhir401/bundles/EXM529-1.0.000/EXM529-1.0.000-files/library-deps-EXM529-1.0.000-bundle.json
@@ -58,7 +58,7 @@
         "relatedArtifact": [
           {
             "type": "depends-on",
-            "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-FHIRHelpers|4.0.1"
+            "resource": "Library/library-FHIRHelpers-4.0.1"
           }
         ],
         "dataRequirement": [
@@ -190,7 +190,7 @@
         "relatedArtifact": [
           {
             "type": "depends-on",
-            "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-FHIRHelpers|4.0.1"
+            "resource": "Library/library-FHIRHelpers-4.0.1"
           }
         ],
         "dataRequirement": [

--- a/fhir401/input/resources/library/library-AdultOutpatientEncounters-2.0.000.json
+++ b/fhir401/input/resources/library/library-AdultOutpatientEncounters-2.0.000.json
@@ -52,7 +52,7 @@
   "relatedArtifact": [
     {
       "type": "depends-on",
-      "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-FHIRHelpers|4.0.1"
+      "resource": "Library/library-FHIRHelpers-4.0.1"
     }
   ],
   "dataRequirement": [

--- a/fhir401/input/resources/library/library-AdvancedIllnessandFrailtyExclusion-6.0.000.json
+++ b/fhir401/input/resources/library/library-AdvancedIllnessandFrailtyExclusion-6.0.000.json
@@ -52,11 +52,11 @@
   "relatedArtifact": [
     {
       "type": "depends-on",
-      "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-FHIRHelpers|4.0.1"
+      "resource": "Library/library-FHIRHelpers-4.0.1"
     },
     {
       "type": "depends-on",
-      "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-MATGlobalCommonFunctions|5.0.000"
+      "resource": "Library/library-MATGlobalCommonFunctions-5.0.000"
     }
   ],
   "dataRequirement": [

--- a/fhir401/input/resources/library/library-EXM104-9.1.000.json
+++ b/fhir401/input/resources/library/library-EXM104-9.1.000.json
@@ -52,19 +52,19 @@
   "relatedArtifact": [
     {
       "type": "depends-on",
-      "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-FHIRHelpers|4.0.1"
+      "resource": "Library/library-FHIRHelpers-4.0.1"
     },
     {
       "type": "depends-on",
-      "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-MATGlobalCommonFunctions|5.0.000"
+      "resource": "Library/library-MATGlobalCommonFunctions-5.0.000"
     },
     {
       "type": "depends-on",
-      "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-SupplementalDataElements|2.0.0"
+      "resource": "Library/library-SupplementalDataElements-2.0.0"
     },
     {
       "type": "depends-on",
-      "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-TJCOverall|5.0.000"
+      "resource": "Library/library-TJCOverall-5.0.000"
     }
   ],
   "dataRequirement": [

--- a/fhir401/input/resources/library/library-EXM105-9.1.000.json
+++ b/fhir401/input/resources/library/library-EXM105-9.1.000.json
@@ -52,19 +52,19 @@
   "relatedArtifact": [
     {
       "type": "depends-on",
-      "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-FHIRHelpers|4.0.1"
+      "resource": "Library/library-FHIRHelpers-4.0.1"
     },
     {
       "type": "depends-on",
-      "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-MATGlobalCommonFunctions|5.0.000"
+      "resource": "Library/library-MATGlobalCommonFunctions-5.0.000"
     },
     {
       "type": "depends-on",
-      "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-SupplementalDataElements|2.0.0"
+      "resource": "Library/library-SupplementalDataElements-2.0.0"
     },
     {
       "type": "depends-on",
-      "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-TJCOverall|5.0.000"
+      "resource": "Library/library-TJCOverall-5.0.000"
     }
   ],
   "dataRequirement": [

--- a/fhir401/input/resources/library/library-EXM108-9.2.000.json
+++ b/fhir401/input/resources/library/library-EXM108-9.2.000.json
@@ -52,23 +52,23 @@
   "relatedArtifact": [
     {
       "type": "depends-on",
-      "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-FHIRHelpers|4.0.1"
+      "resource": "Library/library-FHIRHelpers-4.0.1"
     },
     {
       "type": "depends-on",
-      "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-MATGlobalCommonFunctions|5.0.000"
+      "resource": "Library/library-MATGlobalCommonFunctions-5.0.000"
     },
     {
       "type": "depends-on",
-      "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-SupplementalDataElements|2.0.0"
+      "resource": "Library/library-SupplementalDataElements-2.0.0"
     },
     {
       "type": "depends-on",
-      "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-VTEICU|5.0.000"
+      "resource": "Library/library-VTEICU-5.0.000"
     },
     {
       "type": "depends-on",
-      "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-TJCOverall|5.0.000"
+      "resource": "Library/library-TJCOverall-5.0.000"
     }
   ],
   "dataRequirement": [

--- a/fhir401/input/resources/library/library-EXM124-9.0.000.json
+++ b/fhir401/input/resources/library/library-EXM124-9.0.000.json
@@ -52,23 +52,23 @@
   "relatedArtifact": [
     {
       "type": "depends-on",
-      "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-FHIRHelpers|4.0.1"
+      "resource": "Library/library-FHIRHelpers-4.0.1"
     },
     {
       "type": "depends-on",
-      "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-Hospice|2.0.000"
+      "resource": "Library/library-Hospice-2.0.000"
     },
     {
       "type": "depends-on",
-      "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-AdultOutpatientEncounters|2.0.000"
+      "resource": "Library/library-AdultOutpatientEncounters-2.0.000"
     },
     {
       "type": "depends-on",
-      "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-MATGlobalCommonFunctions|5.0.000"
+      "resource": "Library/library-MATGlobalCommonFunctions-5.0.000"
     },
     {
       "type": "depends-on",
-      "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-SupplementalDataElements|2.0.0"
+      "resource": "Library/library-SupplementalDataElements-2.0.0"
     }
   ],
   "dataRequirement": [

--- a/fhir401/input/resources/library/library-EXM125-8.0.000.json
+++ b/fhir401/input/resources/library/library-EXM125-8.0.000.json
@@ -52,23 +52,23 @@
   "relatedArtifact": [
     {
       "type": "depends-on",
-      "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-FHIRHelpers|4.0.1"
+      "resource": "Library/library-FHIRHelpers-4.0.1"
     },
     {
       "type": "depends-on",
-      "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-Hospice|2.0.000"
+      "resource": "Library/library-Hospice-2.0.000"
     },
     {
       "type": "depends-on",
-      "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-AdultOutpatientEncounters|2.0.000"
+      "resource": "Library/library-AdultOutpatientEncounters-2.0.000"
     },
     {
       "type": "depends-on",
-      "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-MATGlobalCommonFunctions|5.0.000"
+      "resource": "Library/library-MATGlobalCommonFunctions-5.0.000"
     },
     {
       "type": "depends-on",
-      "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-SupplementalDataElements|2.0.0"
+      "resource": "Library/library-SupplementalDataElements-2.0.0"
     }
   ],
   "dataRequirement": [

--- a/fhir401/input/resources/library/library-EXM130-8.0.000.json
+++ b/fhir401/input/resources/library/library-EXM130-8.0.000.json
@@ -52,23 +52,23 @@
   "relatedArtifact": [
     {
       "type": "depends-on",
-      "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-FHIRHelpers|4.0.1"
+      "resource": "Library/library-FHIRHelpers-4.0.1"
     },
     {
       "type": "depends-on",
-      "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-Hospice|2.0.000"
+      "resource": "Library/library-Hospice-2.0.000"
     },
     {
       "type": "depends-on",
-      "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-AdultOutpatientEncounters|2.0.000"
+      "resource": "Library/library-AdultOutpatientEncounters-2.0.000"
     },
     {
       "type": "depends-on",
-      "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-MATGlobalCommonFunctions|5.0.000"
+      "resource": "Library/library-MATGlobalCommonFunctions-5.0.000"
     },
     {
       "type": "depends-on",
-      "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-SupplementalDataElements|2.0.0"
+      "resource": "Library/library-SupplementalDataElements-2.0.0"
     }
   ],
   "dataRequirement": [

--- a/fhir401/input/resources/library/library-EXM349-3.0.000.json
+++ b/fhir401/input/resources/library/library-EXM349-3.0.000.json
@@ -52,15 +52,15 @@
   "relatedArtifact": [
     {
       "type": "depends-on",
-      "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-FHIRHelpers|4.0.1"
+      "resource": "Library/library-FHIRHelpers-4.0.1"
     },
     {
       "type": "depends-on",
-      "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-MATGlobalCommonFunctions|5.0.000"
+      "resource": "Library/library-MATGlobalCommonFunctions-5.0.000"
     },
     {
       "type": "depends-on",
-      "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-SupplementalDataElements|2.0.0"
+      "resource": "Library/library-SupplementalDataElements-2.0.0"
     }
   ],
   "dataRequirement": [

--- a/fhir401/input/resources/library/library-EXM506-3.0.000.json
+++ b/fhir401/input/resources/library/library-EXM506-3.0.000.json
@@ -52,15 +52,15 @@
   "relatedArtifact": [
     {
       "type": "depends-on",
-      "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-MATGlobalCommonFunctions|5.0.000"
+      "resource": "Library/library-MATGlobalCommonFunctions-5.0.000"
     },
     {
       "type": "depends-on",
-      "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-FHIRHelpers|4.0.1"
+      "resource": "Library/library-FHIRHelpers-4.0.1"
     },
     {
       "type": "depends-on",
-      "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-SupplementalDataElements|2.0.0"
+      "resource": "Library/library-SupplementalDataElements-2.0.0"
     }
   ],
   "dataRequirement": [

--- a/fhir401/input/resources/library/library-EXM529-1.0.000.json
+++ b/fhir401/input/resources/library/library-EXM529-1.0.000.json
@@ -52,15 +52,15 @@
   "relatedArtifact": [
     {
       "type": "depends-on",
-      "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-FHIRHelpers|4.0.1"
+      "resource": "Library/library-FHIRHelpers-4.0.1"
     },
     {
       "type": "depends-on",
-      "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-MATGlobalCommonFunctions|5.0.000"
+      "resource": "Library/library-MATGlobalCommonFunctions-5.0.000"
     },
     {
       "type": "depends-on",
-      "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-SupplementalDataElements|2.0.0"
+      "resource": "Library/library-SupplementalDataElements-2.0.0"
     }
   ],
   "dataRequirement": [

--- a/fhir401/input/resources/library/library-Hospice-2.0.000.json
+++ b/fhir401/input/resources/library/library-Hospice-2.0.000.json
@@ -52,11 +52,11 @@
   "relatedArtifact": [
     {
       "type": "depends-on",
-      "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-MATGlobalCommonFunctions|5.0.000"
+      "resource": "Library/library-MATGlobalCommonFunctions-5.0.000"
     },
     {
       "type": "depends-on",
-      "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-FHIRHelpers|4.0.1"
+      "resource": "Library/library-FHIRHelpers-4.0.1"
     }
   ],
   "dataRequirement": [

--- a/fhir401/input/resources/library/library-MATGlobalCommonFunctions-5.0.000.json
+++ b/fhir401/input/resources/library/library-MATGlobalCommonFunctions-5.0.000.json
@@ -52,7 +52,7 @@
   "relatedArtifact": [
     {
       "type": "depends-on",
-      "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-FHIRHelpers|4.0.1"
+      "resource": "Library/library-FHIRHelpers-4.0.1"
     }
   ],
   "dataRequirement": [

--- a/fhir401/input/resources/library/library-SupplementalDataElements-2.0.0.json
+++ b/fhir401/input/resources/library/library-SupplementalDataElements-2.0.0.json
@@ -52,7 +52,7 @@
   "relatedArtifact": [
     {
       "type": "depends-on",
-      "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-FHIRHelpers|4.0.1"
+      "resource": "Library/library-FHIRHelpers-4.0.1"
     }
   ],
   "dataRequirement": [

--- a/fhir401/input/resources/library/library-TJCOverall-5.0.000.json
+++ b/fhir401/input/resources/library/library-TJCOverall-5.0.000.json
@@ -52,15 +52,15 @@
   "relatedArtifact": [
     {
       "type": "depends-on",
-      "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-FHIRHelpers|4.0.1"
+      "resource": "Library/library-FHIRHelpers-4.0.1"
     },
     {
       "type": "depends-on",
-      "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-MATGlobalCommonFunctions|5.0.000"
+      "resource": "Library/library-MATGlobalCommonFunctions-5.0.000"
     },
     {
       "type": "depends-on",
-      "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-SupplementalDataElements|2.0.0"
+      "resource": "Library/library-SupplementalDataElements-2.0.0"
     }
   ],
   "dataRequirement": [

--- a/fhir401/input/resources/library/library-VTEICU-5.0.000.json
+++ b/fhir401/input/resources/library/library-VTEICU-5.0.000.json
@@ -52,11 +52,11 @@
   "relatedArtifact": [
     {
       "type": "depends-on",
-      "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-FHIRHelpers|4.0.1"
+      "resource": "Library/library-FHIRHelpers-4.0.1"
     },
     {
       "type": "depends-on",
-      "resource": "http://fhir.org/guides/dbcg/connectathon/Library/library-MATGlobalCommonFunctions|5.0.000"
+      "resource": "Library/library-MATGlobalCommonFunctions-5.0.000"
     }
   ],
   "content": [

--- a/travis/calculateMeasures.js
+++ b/travis/calculateMeasures.js
@@ -54,18 +54,18 @@ async function calculateMeasuresAndCompare() {
     let bundleResourceInfos = await testDataHelpers.loadTestDataFolder(testPatientMeasure.path);
 
     // Execute the measure, i.e. get the MeasureReport from cqf-ruler
-    let report = await fhirInteractions.getMeasureReport(cqfMeasure.id)
+    let report = await fhirInteractions.getMeasureReport(cqfMeasure.id);
     // Load the reference report from the test data
     let referenceReport = await testDataHelpers.loadReferenceMeasureReport(testPatientMeasure.measureReportPath);
 
     // Compare measure reports and get the list of information about patients with discrepancies
-    let badPatients = measureReportCompare.compareMeasureReports(referenceReport, report)
+    let badPatients = measureReportCompare.compareMeasureReports(referenceReport, report);
 
     // Add to the measure info to print at the end
     measureDiffInfo.push({
       exmId: testPatientMeasure.exmId,
       badPatients: badPatients
-    })
+    });
 
     // Clean up the test patients so they don't pollute the next test.
     console.log(`Removing test data for ${testPatientMeasure.exmId}`);
@@ -95,7 +95,7 @@ calculateMeasuresAndCompare()
         measureDiff.badPatients.forEach((patient) => {
           console.log(`|- ${patient.patientName}`);
           patient.issues.forEach((issue) => {
-            console.log(`|   ${issue}`)
+            console.log(`|   ${issue}`);
           });
         });
 

--- a/travis/setup.sh
+++ b/travis/setup.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 echo "> Cloning FHIR Generated Patients..."
-git clone --single-branch --branch exm_506-recalculate https://github.com/projecttacoma/fhir-patient-generator.git
+git clone --single-branch --branch add-measure-version https://github.com/projecttacoma/fhir-patient-generator.git
 
 echo "> Fetching CQF-tooling JAR"
 ./travis/download_cqf_tooling.sh

--- a/travis/setup.sh
+++ b/travis/setup.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 echo "> Cloning FHIR Generated Patients..."
-git clone --single-branch --branch add-measure-version https://github.com/projecttacoma/fhir-patient-generator.git
+git clone --single-branch --branch master https://github.com/projecttacoma/fhir-patient-generator.git
 
 echo "> Fetching CQF-tooling JAR"
 ./travis/download_cqf_tooling.sh

--- a/travis/testDataHelpers.js
+++ b/travis/testDataHelpers.js
@@ -26,7 +26,8 @@ async function getTestMeasureList() {
   let measureDirInfo = applicableMeasuresDirs.map((measureDir) => {
     /** @type {TestMeasureInfo} */
     let testDirInfo = {
-      exmId: measureDir,
+      // format exmId into simple, non-versioned id
+      exmId: measureDir.includes('-') ? measureDir.split('-')[0] : measureDir,
       path: `./fhir-patient-generator/${measureDir}/patients-r4`
     };
     let measureReportFile = fs.readdirSync(testDirInfo.path).find((filename) => { return filename.includes('measure-report.json')});


### PR DESCRIPTION
## Summary
This updates the CI tool to use the fhir patient generator with versioned measure folders. 
It also updates some typos in the readme and does a bit of code cleanup.
This currently also includes changes to move from using canonical urls to relative urls in library depends-on statements, which is in a separate PR (https://github.com/projecttacoma/connectathon/pull/11), but can be pulled in with this PR instead.

## New behavior
CI tool adapts to the new fpg folder name structure

## Code changes
CI tool uses the folder names but excludes anything after the "-" to create the measure id.

## Testing guidance
CI Tool tests pass